### PR TITLE
Issue #50: Added current portfolio display  to new order dialog title

### DIFF
--- a/src/app/modules/command/widgets/command-widget/command-widget.component.html
+++ b/src/app/modules/command/widgets/command-widget/command-widget.component.html
@@ -19,13 +19,17 @@
       <ats-command-footer *ngIf="activeTab | async as tab" [activeTab]='tab'></ats-command-footer>
     </ng-container>
   </nz-modal>
-</div>
 
-<ng-template #header>
+  <ng-template #header>
   <span class="title">
     <button nz-button class='btn-help' nzSize="small" (click)="openHelp()">
       <i nz-icon nzType="question-circle" [nzTheme]="'outline'"></i>
     </button>
-    <label><h2>Выставить заявку</h2></label>
+    <label>
+      <h2>Выставить заявку<span *ngIf="command?.user as portfolio"> ({{portfolio.portfolio}}:{{portfolio.exchange}})</span></h2>
+    </label>
   </span>
-</ng-template>
+  </ng-template>
+</div>
+
+

--- a/src/app/modules/command/widgets/command-widget/command-widget.component.ts
+++ b/src/app/modules/command/widgets/command-widget/command-widget.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { NzTabChangeEvent, NzTabComponent } from 'ng-zorro-antd/tabs';
+import { NzTabChangeEvent } from 'ng-zorro-antd/tabs';
 import { BehaviorSubject, filter, Observable, of } from 'rxjs';
 import { CommandParams } from 'src/app/shared/models/commands/command-params.model';
 import { ModalService } from 'src/app/shared/services/modal.service';


### PR DESCRIPTION
Fixes Issue #50 

# Description

Added current portfolio display to new order dialog title

# Testing

Open new order dialog. Check dialog title. Title should contain current portfolio description

# Risk

No breaking changes

# Do you agree with those?
- [x] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [x] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
