### PR TITLE
Fixed 'show settings' issue #4

### DIFF
--- a/src/app/modules/dashboard/components/navbar/navbar.component.html
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.html
@@ -74,7 +74,7 @@
 <nz-dropdown-menu #rightMenu="nzDropdownMenu">
   <ul nz-menu>
     <li nz-menu-item (click)="openTerminalSettings()" class='menu-item' >
-      <span><i nz-icon nzType="user" nzTheme="outline"></i> <label>&nbsp;Профель</label></span>
+      <span><i nz-icon nzType="user" nzTheme="outline"></i> <label>&nbsp;Профиль</label></span>
     </li>
     <li nz-menu-item class='menu-item' >
       <span>

--- a/src/app/modules/dashboard/components/parent-widget/parent-widget.component.html
+++ b/src/app/modules/dashboard/components/parent-widget/parent-widget.component.html
@@ -4,6 +4,7 @@
     (switchSettingsEvent)="onSwitchSettings($event)"
     (linkChangedEvent)="onLinkedChanged($event)"
     [hasSettings]="hasSettings()"
+    [shouldShowSettings]="shouldShowSettings"
     [hasHelp]="hasHelp()"></ats-widget-header>
   <ats-orderbook-widget *ngIf="widget.gridItem.type === 'order-book'"
     [guid]="getGuid()"

--- a/src/app/modules/dashboard/components/parent-widget/parent-widget.component.ts
+++ b/src/app/modules/dashboard/components/parent-widget/parent-widget.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   Input,
   EventEmitter,
-  ViewEncapsulation,
   OnInit,
   Output,
 } from '@angular/core';

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.ts
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.ts
@@ -19,6 +19,8 @@ export class WidgetHeaderComponent implements OnInit {
   @Input()
   hasSettings!: boolean;
   @Input()
+  shouldShowSettings = false;
+  @Input()
   hasHelp!: boolean;
   @Output()
   switchSettingsEvent = new EventEmitter<boolean>();
@@ -26,8 +28,6 @@ export class WidgetHeaderComponent implements OnInit {
   linkChangedEvent = new EventEmitter<boolean>();
 
   joyrideContent = joyrideContent;
-
-  private shouldShowSettings = false;
   settings$?: Observable<AnySettings>;
   private settings?: AnySettings;
 

--- a/src/app/modules/orderbook/components/orderbook-settings/orderbook-settings.component.ts
+++ b/src/app/modules/orderbook/components/orderbook-settings/orderbook-settings.component.ts
@@ -41,14 +41,18 @@ export class OrderbookSettingsComponent implements OnInit {
           depth: new FormControl(settings.depth, [Validators.required, Validators.min(0), Validators.max(20)]),
           instrumentGroup: new FormControl(settings.instrumentGroup),
           showChart: new FormControl(settings.showChart),
-          showTable: new FormControl(settings.showTable),
+          showTable: new FormControl(settings.showTable)
         } as SettingsFormControls) as SettingsFormGroup;
       }
     });
   }
 
   submitForm(): void {
-    this.service.setSettings({...this.form.value, guid: this.guid, linkToActive: false});
+    this.service.setSettings({
+      ...this.form.value,
+      guid: this.guid,
+      linkToActive: false
+    });
     this.settingsChange.emit();
   }
 }


### PR DESCRIPTION
Fixes Issue #4 

# Description
Fixed the double click issue

# Testing
Try to click on settings icon in any widget after changing settings (e.g. Ticker)

# Risk
No breaking changes

# Do you agree with those?
- [+ ] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [+ ] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
