### PR TITLE
Issue #98: Move help button next to close button in  command dialog

### DIFF
--- a/src/app/modules/command/widgets/command-widget/command-widget.component.html
+++ b/src/app/modules/command/widgets/command-widget/command-widget.component.html
@@ -1,7 +1,8 @@
 <div *ngIf="commandParams$ | async as command">
   <nz-modal nzOkText="Выставить" nzCancelText="Отмена" [nzVisible]='isVisible$ | async'
     [nzTitle]="header" (nzOnCancel)="handleCancel()"
-    [nzFooter]='null' [nzMaskClosable]='false'>
+    [nzFooter]='null' [nzMaskClosable]='false'
+    nzClosable="false">
     <ng-container *nzModalContent>
       <ats-command-header [symbol]='command.instrument.symbol' [exchange]='command.instrument.exchange'
         [instrumentGroup]="command.instrument.instrumentGroup ?? ''"></ats-command-header>
@@ -21,14 +22,21 @@
   </nz-modal>
 
   <ng-template #header>
-  <span class="title">
-    <button nz-button class='btn-help' nzSize="small" (click)="openHelp()">
-      <i nz-icon nzType="question-circle" [nzTheme]="'outline'"></i>
-    </button>
-    <label>
-      <h2>Выставить заявку<span *ngIf="command?.user as portfolio"> ({{portfolio.portfolio}}:{{portfolio.exchange}})</span></h2>
-    </label>
-  </span>
+  <div class="title">
+    <div class="left">
+      <label>
+        <h2>Выставить заявку<span *ngIf="command?.user as portfolio"> ({{portfolio.portfolio}}:{{portfolio.exchange}})</span></h2>
+      </label>
+    </div>
+    <div class="right">
+      <button nz-button (click)="openHelp()" aria-label="Help">
+        <i nz-icon nzType="question-circle"  [nzTheme]="'outline'"></i>
+      </button>
+      <button nz-button (click)="handleCancel()" aria-label="Close">
+        <i nz-icon nzType="close" [nzTheme]="'outline'"></i>
+      </button>
+    </div>
+  </div>
   </ng-template>
 </div>
 

--- a/src/app/modules/command/widgets/command-widget/command-widget.component.less
+++ b/src/app/modules/command/widgets/command-widget/command-widget.component.less
@@ -3,7 +3,7 @@
 .title {
   display: flex;
   justify-content: space-between;
-  align-items: start;
+  align-items: flex-start;
 
   .right {
     white-space: nowrap;

--- a/src/app/modules/command/widgets/command-widget/command-widget.component.less
+++ b/src/app/modules/command/widgets/command-widget/command-widget.component.less
@@ -1,8 +1,23 @@
+@import (reference) '/src/styles.less';
 
 .title {
   display: flex;
-}
+  justify-content: space-between;
+  align-items: start;
 
-.btn-help {
-  border: none;
+  .right {
+    white-space: nowrap;
+    margin-right: -8px;
+
+    button {
+      border: none;
+      opacity: 0.5;
+
+      &:hover, &:focus {
+        color: @icon-color-hover;
+        text-decoration: none;
+        opacity: 1;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes Issue #98

# Description

Help button moved next to close button in  command dialog

# Testing

Execute steps from issue description

# Risk

No risk

# Do you agree with those?
- [x] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [x] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
