### PR TITLE
add context menu in instrument select

### DIFF
--- a/src/app/modules/command/components/stop-command/stop-command.component.spec.ts
+++ b/src/app/modules/command/components/stop-command/stop-command.component.spec.ts
@@ -11,7 +11,11 @@ describe('StopCommandComponent', () => {
   let component: StopCommandComponent;
   let fixture: ComponentFixture<StopCommandComponent>;
 
-  const spyCommands = jasmine.createSpyObj('CommandsService', ['setStopCommand']);
+  const spyCommands = jasmine.createSpyObj(
+    'CommandsService',
+    ['setStopCommand'],
+    {stopCommandErr$: of(null)}
+    );
 
   const timezoneConverterServiceSpy = jasmine.createSpyObj('TimezoneConverterService', ['getConverter']);
   timezoneConverterServiceSpy.getConverter.and.returnValue(of(new TimezoneConverter(TimezoneDisplayOption.MskTime)));

--- a/src/app/modules/dashboard/components/navbar/navbar.component.html
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.html
@@ -55,29 +55,7 @@
 
 
 <nz-dropdown-menu #widgetsMenu="nzDropdownMenu">
-  <ul nz-menu>
-    <li nz-menu-item (click)="addItem(names.instrumentSelect)">
-      <span><i nz-icon nzType="eye" nzTheme="outline"></i> <label><strong>&nbsp;Инструменты</strong></label></span>
-    </li>
-    <li nz-menu-item (click)="addItem(names.orderBook)">
-      <span><i nz-icon nzType="ordered-list" nzTheme="outline"></i> <label>&nbsp;Стакан</label></span>
-    </li>
-    <li nz-menu-item (click)="addItem(names.lightChart)">
-      <span><i nz-icon nzType="sliders" nzTheme="outline"></i><label>&nbsp;График</label></span>
-    </li>
-    <li nz-menu-item (click)="addItem(names.blotter)">
-      <span><i nz-icon nzType="table" nzTheme="outline"></i><label>&nbsp;Блоттер</label></span>
-    </li>
-    <li nz-menu-item (click)="addItem(names.instrumentInfo)">
-      <span><i nz-icon nzType="info" nzTheme="outline"></i><label>&nbsp;Инфо</label></span>
-    </li>
-    <li nz-menu-item (click)="addItem(names.news)">
-      <span><i nz-icon nzType="read" nzTheme="outline"></i><label> Новости</label></span>
-    </li>
-    <li nz-menu-item (click)="addItem(names.allTrades)">
-      <span><i nz-icon nzType="unordered-list" nzTheme="outline"></i><label> Все сделки</label></span>
-    </li>
-  </ul>
+  <ats-widget-menu (selected)="addItem($event)"></ats-widget-menu>
 </nz-dropdown-menu>
 
 <nz-dropdown-menu #rightMenu="nzDropdownMenu">

--- a/src/app/modules/instruments/components/watchlist-table/watchlist-table.component.html
+++ b/src/app/modules/instruments/components/watchlist-table/watchlist-table.component.html
@@ -16,7 +16,11 @@
     </tr>
   </thead>
   <tbody>
-    <tr *ngFor="let inst of nzTable.data; trackBy: getTrackKey" (click)='makeActive(inst.instrument)'>
+    <tr
+      *ngFor="let inst of nzTable.data; trackBy: getTrackKey"
+      (click)='makeActive(inst.instrument)'
+      (contextmenu)="contextMenu($event, menu, inst.instrument)"
+    >
       <td *ngIf="isVisibleColumn('symbol')" class="ticker">{{ inst.instrument.symbol }}</td>
       <td *ngIf="isVisibleColumn('price')">
         <ats-price-tick [price]='inst.price' [prevPrice]='inst.prevTickPrice'>
@@ -39,3 +43,7 @@
     </tr>
   </tbody>
 </nz-table>
+
+<nz-dropdown-menu #menu="nzDropdownMenu">
+  <ats-widget-menu [showedWidgets]="showedWidgetNames" (selected)="addWidget($event)"></ats-widget-menu>
+</nz-dropdown-menu>

--- a/src/app/modules/instruments/components/watchlist-table/watchlist-table.component.ts
+++ b/src/app/modules/instruments/components/watchlist-table/watchlist-table.component.ts
@@ -9,6 +9,9 @@ import { WatchlistCollectionService } from '../../services/watchlist-collection.
 import { filter, map } from 'rxjs/operators';
 import { getPropertyFromPath } from "../../../../shared/utils/object-helper";
 import { allInstrumentsColumns, ColumnIds } from "../../../../shared/models/settings/instrument-select-settings.model";
+import { NzContextMenuService, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
+import { WidgetNames } from "../../../../shared/models/enums/widget-names";
+import { DashboardService } from "../../../../shared/services/dashboard.service";
 
 @Component({
   selector: 'ats-watchlist-table[guid]',
@@ -33,11 +36,21 @@ export class WatchlistTableComponent implements OnInit {
     openPrice: this.getSortFn('openPrice'),
     closePrice: this.getSortFn('closePrice'),
   };
+  showedWidgetNames = [
+    WidgetNames.lightChart,
+    WidgetNames.orderBook,
+    WidgetNames.allTrades,
+    WidgetNames.instrumentInfo
+  ];
+
+  private selectedInstrument: InstrumentKey | null = null;
 
   constructor(
     private readonly store: Store,
     private readonly watchInstrumentsService: WatchInstrumentsService,
-    private readonly watchlistCollectionService: WatchlistCollectionService
+    private readonly watchlistCollectionService: WatchlistCollectionService,
+    private readonly nzContextMenuService: NzContextMenuService,
+    private readonly dashBoardService: DashboardService
   ) {
   }
 
@@ -70,6 +83,30 @@ export class WatchlistTableComponent implements OnInit {
 
   isVisibleColumn(colName: string): boolean {
     return this.displayedColumns.map(c => c.columnId).includes(colName);
+  }
+
+  contextMenu($event: MouseEvent, menu: NzDropdownMenuComponent, selectedInstrument: InstrumentKey): void {
+    this.selectedInstrument = selectedInstrument;
+    this.nzContextMenuService.create($event, menu);
+  }
+
+  addWidget(type: WidgetNames): void {
+    const settings = {
+      gridItem: {
+        x: 0,
+        y: 0,
+        cols: 1,
+        rows: 1,
+        type: type,
+      },
+    };
+
+    const additionalSettings = {
+        linkToActive: false,
+        ...this.selectedInstrument
+      };
+
+    this.dashBoardService.addWidget(settings, additionalSettings);
   }
 
   private getSortFn(propName: string): (a: InstrumentKey, b: InstrumentKey) => number {

--- a/src/app/modules/instruments/services/watch-instruments.service.spec.ts
+++ b/src/app/modules/instruments/services/watch-instruments.service.spec.ts
@@ -72,7 +72,7 @@ describe('WatchInstrumentsService', () => {
       } as WatchlistCollection;
     });
 
-    service.getWatched({ guid: 'guid', activeListId: '123' });
+    service.getWatched({ guid: 'guid', activeListId: '123', instrumentColumns: [] });
 
     expect(watchlistCollectionServiceSpy.getWatchlistCollection).toHaveBeenCalledTimes(1);
   });
@@ -103,7 +103,7 @@ describe('WatchInstrumentsService', () => {
       return defaultList.items;
     });
 
-    service.getWatched({ guid: 'guid', activeListId: undefined });
+    service.getWatched({ guid: 'guid', activeListId: undefined, instrumentColumns: [] });
 
     expect(requestedListId).toEqual(defaultList.id);
   });
@@ -124,7 +124,7 @@ describe('WatchInstrumentsService', () => {
       return list.items;
     });
 
-    service.getWatched({ guid: 'guid', activeListId: '123' });
+    service.getWatched({ guid: 'guid', activeListId: '123', instrumentColumns: [] });
     collectionChangedMock.next(null);
 
     // first call when we start watching

--- a/src/app/modules/instruments/services/watch-instruments.service.ts
+++ b/src/app/modules/instruments/services/watch-instruments.service.ts
@@ -132,9 +132,9 @@ export class WatchInstrumentsService extends BaseService<InstrumentSelectSetting
           prevTickPrice: 0,
           dayChange: 0,
           price: 0,
-          minPrice: candle.low,
-          maxPrice: candle.high,
-          volume: candle.volume,
+          minPrice: candle?.low,
+          maxPrice: candle?.high,
+          volume: candle?.volume,
           dayChangePerPrice: 0,
         }),
         take(1)

--- a/src/app/shared/components/widget-menu/widget-menu.component.html
+++ b/src/app/shared/components/widget-menu/widget-menu.component.html
@@ -1,0 +1,50 @@
+<ul nz-menu>
+  <li
+    nz-menu-item
+    (click)="selected.emit(widgetNames.instrumentSelect)"
+    *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.instrumentSelect)"
+  >
+    <span><i nz-icon nzType="eye" nzTheme="outline"></i> <label><strong>&nbsp;Инструменты</strong></label></span>
+  </li>
+  <li
+    nz-menu-item
+    (click)="selected.emit(widgetNames.orderBook)"
+    *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.orderBook)"
+  >
+    <span><i nz-icon nzType="ordered-list" nzTheme="outline"></i> <label>&nbsp;Стакан</label></span>
+  </li>
+  <li
+    nz-menu-item
+    (click)="selected.emit(widgetNames.lightChart)"
+    *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.lightChart)"
+  >
+    <span><i nz-icon nzType="sliders" nzTheme="outline"></i><label>&nbsp;График</label></span>
+  </li>
+  <li nz-menu-item
+      (click)="selected.emit(widgetNames.blotter)"
+      *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.blotter)"
+  >
+    <span><i nz-icon nzType="table" nzTheme="outline"></i><label>&nbsp;Блоттер</label></span>
+  </li>
+  <li
+    nz-menu-item
+    (click)="selected.emit(widgetNames.instrumentInfo)"
+    *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.instrumentInfo)"
+  >
+    <span><i nz-icon nzType="info" nzTheme="outline"></i><label>&nbsp;Инфо</label></span>
+  </li>
+  <li
+    nz-menu-item
+    (click)="selected.emit(widgetNames.news)"
+    *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.news)"
+  >
+    <span><i nz-icon nzType="read" nzTheme="outline"></i><label> Новости</label></span>
+  </li>
+  <li
+    nz-menu-item
+    (click)="selected.emit(widgetNames.allTrades)"
+    *ngIf="!showedWidgets.length || showedWidgets.includes(widgetNames.allTrades)"
+  >
+    <span><i nz-icon nzType="unordered-list" nzTheme="outline"></i><label> Все сделки</label></span>
+  </li>
+</ul>

--- a/src/app/shared/components/widget-menu/widget-menu.component.spec.ts
+++ b/src/app/shared/components/widget-menu/widget-menu.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WidgetMenuComponent } from './widget-menu.component';
+
+describe('WidgetMenuComponent', () => {
+  let component: WidgetMenuComponent;
+  let fixture: ComponentFixture<WidgetMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ WidgetMenuComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WidgetMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/widget-menu/widget-menu.component.ts
+++ b/src/app/shared/components/widget-menu/widget-menu.component.ts
@@ -1,0 +1,18 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { WidgetNames } from "../../models/enums/widget-names";
+
+@Component({
+  selector: 'ats-widget-menu',
+  templateUrl: './widget-menu.component.html',
+  styleUrls: ['./widget-menu.component.less']
+})
+export class WidgetMenuComponent {
+
+  @Input() public showedWidgets: string[] = [];
+  @Output() public selected = new EventEmitter<string>();
+
+  public widgetNames = WidgetNames;
+
+  constructor() { }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -42,6 +42,7 @@ import { NzSpinModule } from 'ng-zorro-antd/spin';
 import { NzTypographyModule } from 'ng-zorro-antd/typography';
 import { NzRadioModule } from 'ng-zorro-antd/radio';
 import { InfiniteScrollTableComponent } from './components/infinite-scroll-table/infinite-scroll-table.component';
+import { WidgetMenuComponent } from './components/widget-menu/widget-menu.component';
 
 
 @NgModule({
@@ -49,7 +50,8 @@ import { InfiniteScrollTableComponent } from './components/infinite-scroll-table
     PriceTickComponent,
     NumericalDirective,
     LoadingIndicatorComponent,
-    InfiniteScrollTableComponent
+    InfiniteScrollTableComponent,
+    WidgetMenuComponent
   ],
   imports: [
     CommonModule,
@@ -130,8 +132,9 @@ import { InfiniteScrollTableComponent } from './components/infinite-scroll-table
         PriceTickComponent,
         LoadingIndicatorComponent,
         InfiniteScrollTableComponent,
-      // directives
+        // directives
         NumericalDirective,
+        WidgetMenuComponent,
     ],
   providers: [
     {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -132,9 +132,9 @@ import { WidgetMenuComponent } from './components/widget-menu/widget-menu.compon
         PriceTickComponent,
         LoadingIndicatorComponent,
         InfiniteScrollTableComponent,
+        WidgetMenuComponent,
         // directives
         NumericalDirective,
-        WidgetMenuComponent,
     ],
   providers: [
     {


### PR DESCRIPTION
Fixes #283 

# Description

Добавил открытие контекстного меню правой кнопки мыши на элементе таблицы выбора инструментов для добавления виджета, привязанного к выбранному инструменту

# Testing

в виджете выбора инструмента, в таблице инструментов кликнуть правой кнопкой мыши на инструмент, добавить необходимый виджет

# Risk

Вынес меню выбора виджетов в отдельный компонент, поправил логику добавления виджета в navbar

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
