### PR TITLE
Issue #303: Display zero volume items

### DIFF
--- a/src/app/modules/light-chart/utils/price-format-helper.ts
+++ b/src/app/modules/light-chart/utils/price-format-helper.ts
@@ -1,3 +1,5 @@
+import { MathHelper } from "../../../shared/utils/math-helper";
+
 type ShortPriceFormat = { minMove: number; precision: number; };
 
 export class PriceFormatHelper {
@@ -15,23 +17,10 @@ export class PriceFormatHelper {
       };
     }
 
-    const precision = this.getPrecision(minstep);
+    const precision = MathHelper.getPrecision(minstep);
     return {
       precision: precision,
       minMove: Number((10 ** -precision).toFixed(precision))
     } as ShortPriceFormat;
-  }
-
-  private static getPrecision(a: number): number {
-    if (!isFinite(a)) return 0;
-    let e = 1;
-    let p = 0;
-
-    while (Math.round(a * e) / e !== a) {
-      e *= 10;
-      p++;
-    }
-
-    return p;
   }
 }

--- a/src/app/modules/orderbook/components/orderbook-settings/orderbook-settings.component.ts
+++ b/src/app/modules/orderbook/components/orderbook-settings/orderbook-settings.component.ts
@@ -76,6 +76,7 @@ export class OrderbookSettingsComponent implements OnInit, OnDestroy {
       this.guid,
       {
         ...this.form.value,
+        depth: Number(this.form.value.depth),
         linkToActive: false
       });
 

--- a/src/app/modules/orderbook/components/vertical-order-book-settings/vertical-order-book-settings.component.html
+++ b/src/app/modules/orderbook/components/vertical-order-book-settings/vertical-order-book-settings.component.html
@@ -1,6 +1,6 @@
 <p>Настройки</p>
 <div>
-  <form nz-form [nzLayout]="'horizontal'" [formGroup]="form" (ngSubmit)="submitForm()">
+  <form nz-form [nzLayout]="'vertical'" [formGroup]="form" (ngSubmit)="submitForm()">
     <nz-form-item class="compact">
       <nz-form-control nzErrorTip="Введите инструмент">
         <nz-form-label nzRequired nzFor="symbol">Тикер</nz-form-label>
@@ -29,6 +29,14 @@
     <nz-form-item>
       <nz-form-label nzFor="showYieldForBonds">Показывать дох. облигаций</nz-form-label>
       <nz-switch formControlName='showYieldForBonds'></nz-switch>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzFor="showZeroVolumeItems">Показывать цены сделок с нулевым объемом</nz-form-label>
+      <nz-switch formControlName='showZeroVolumeItems'></nz-switch>
+    </nz-form-item>
+    <nz-form-item>
+      <nz-form-label nzFor="showSpreadItems">Показывать цены между лучшими ценами покупки/продажи</nz-form-label>
+      <nz-switch formControlName='showSpreadItems'></nz-switch>
     </nz-form-item>
     <nz-collapse [nzBordered]="false" class="compact">
       <nz-collapse-panel nzHeader="Продвинутые">

--- a/src/app/modules/orderbook/components/vertical-order-book-settings/vertical-order-book-settings.component.ts
+++ b/src/app/modules/orderbook/components/vertical-order-book-settings/vertical-order-book-settings.component.ts
@@ -24,7 +24,9 @@ interface SettingsFormData {
   exchange: string,
   symbol: string,
   instrumentGroup: string,
-  showYieldForBonds: boolean
+  showYieldForBonds: boolean,
+  showZeroVolumeItems: boolean,
+  showSpreadItems: boolean
 }
 
 type SettingsFormControls = { [key in keyof SettingsFormData]: AbstractControl };
@@ -65,7 +67,9 @@ export class VerticalOrderBookSettingsComponent implements OnInit, OnDestroy {
           Validators.min(this.validationOptions.minDepth),
           Validators.max(this.validationOptions.maxDepth)]),
         instrumentGroup: new FormControl(settings.instrumentGroup),
-        showYieldForBonds: new FormControl(settings.showYieldForBonds)
+        showYieldForBonds: new FormControl(settings.showYieldForBonds),
+        showZeroVolumeItems: new FormControl(settings.showZeroVolumeItems),
+        showSpreadItems: new FormControl(settings.showSpreadItems)
       } as SettingsFormControls) as SettingsFormGroup;
     });
   }
@@ -75,6 +79,7 @@ export class VerticalOrderBookSettingsComponent implements OnInit, OnDestroy {
       this.guid,
       {
         ...this.form.value,
+        depth: Number(this.form.value.depth),
         linkToActive: false
       });
 

--- a/src/app/modules/orderbook/components/vertical-order-book/vertical-order-book.component.html
+++ b/src/app/modules/orderbook/components/vertical-order-book/vertical-order-book.component.html
@@ -7,6 +7,7 @@
           'row': true,
           'ask-row': row.rowType === rowTypes.Ask,
           'bid-row': row.rowType === rowTypes.Bid,
+          'spread-row': row.rowType === rowTypes.Spread,
           'best-row': row.isBest,
           'trade-row': (row.volume ?? 0) > 0
           }"

--- a/src/app/modules/orderbook/components/vertical-order-book/vertical-order-book.component.less
+++ b/src/app/modules/orderbook/components/vertical-order-book/vertical-order-book.component.less
@@ -13,9 +13,7 @@
       }
 
       &.best-row {
-        .price-cell {
-          background-color: @sell-color-background;
-        }
+        background-color: fade(@sell-color, 20%);
       }
     }
   }
@@ -27,10 +25,12 @@
       }
 
       &.best-row {
-        .price-cell {
-          background-color: @buy-color-background;
-        }
+        background-color: fade(@buy-color, 20%);
       }
     }
+  }
+
+  .spread-row {
+    background-color: fade(@disabled-color, 7%);
   }
 }

--- a/src/app/modules/orderbook/components/vertical-order-book/vertical-order-book.component.spec.ts
+++ b/src/app/modules/orderbook/components/vertical-order-book/vertical-order-book.component.spec.ts
@@ -27,7 +27,8 @@ describe('VerticalOrderBookComponent', () => {
         useValue: {
           getVerticalOrderBook: jasmine.createSpy('getVerticalOrderBook').and.returnValue(of({
             asks: [],
-            bids: []
+            bids: [],
+            spreadItems: []
           } as VerticalOrderBook))
         }
       },

--- a/src/app/modules/orderbook/models/vertical-order-book.model.ts
+++ b/src/app/modules/orderbook/models/vertical-order-book.model.ts
@@ -7,6 +7,7 @@ export interface OrderBookItem {
 export interface VerticalOrderBook {
   asks: OrderBookItem[];
   bids: OrderBookItem[];
+  spreadItems: OrderBookItem[];
 }
 
 export enum VerticalOrderBookRowType {

--- a/src/app/shared/models/settings/vertical-order-book-settings.model.ts
+++ b/src/app/shared/models/settings/vertical-order-book-settings.model.ts
@@ -3,5 +3,7 @@ import { InstrumentKey } from "../instruments/instrument-key.model";
 
 export interface VerticalOrderBookSettings extends WidgetSettings, InstrumentKey {
   depth?: number,
-  showYieldForBonds: boolean
+  showYieldForBonds: boolean,
+  showZeroVolumeItems: boolean,
+  showSpreadItems: boolean
 }

--- a/src/app/shared/services/widget-factory.service.ts
+++ b/src/app/shared/services/widget-factory.service.ts
@@ -121,6 +121,8 @@ export class WidgetFactoryService {
       instrumentGroup: this.selectedInstrument.instrumentGroup,
       isin: this.selectedInstrument.isin,
       showYieldForBonds: false,
+      showZeroVolumeItems: false,
+      showSpreadItems: false,
       title: `Стакан ${this.selectedInstrument.symbol} ${group ? '(' + group + ')' : ''}`
     };
 

--- a/src/app/shared/utils/math-helper.ts
+++ b/src/app/shared/utils/math-helper.ts
@@ -12,4 +12,22 @@ export class MathHelper {
     const multiplier = Math.pow(10, decimals);
     return Math.round((num + Number.EPSILON) * multiplier) / multiplier;
   }
+
+  /**
+   * Returns the number of decimal places
+   * @param a Target number
+   * @returns The number of decimal places
+   */
+  static getPrecision(a: number): number {
+    if (!isFinite(a)) return 0;
+    let e = 1;
+    let p = 0;
+
+    while (Math.round(a * e) / e !== a) {
+      e *= 10;
+      p++;
+    }
+
+    return p;
+  }
 }

--- a/src/app/shared/utils/settings-helper.ts
+++ b/src/app/shared/utils/settings-helper.ts
@@ -89,7 +89,9 @@ export function isVerticalOrderBookSettings(
     'symbol' in settings &&
     'exchange' in settings &&
     'depth' in settings &&
-    'showYieldForBonds' in settings
+    'showYieldForBonds' in settings &&
+    'showZeroVolumeItems' in settings &&
+    'showSpreadItems' in settings
   );
 }
 /**
@@ -266,7 +268,9 @@ export function isEqualVerticalOrderKookSettings(
       settings1.linkToActive == settings2.linkToActive &&
       settings1.exchange == settings2.exchange &&
       settings1.depth == settings2.depth &&
-      settings1.showYieldForBonds == settings2.showYieldForBonds
+      settings1.showYieldForBonds == settings2.showYieldForBonds &&
+      settings1.showZeroVolumeItems == settings2.showZeroVolumeItems &&
+      settings1.showSpreadItems == settings2.showSpreadItems
     );
   } else return false;
 }

--- a/src/styles/colors.less
+++ b/src/styles/colors.less
@@ -1,6 +1,6 @@
 // enumerate common application colors here
-@sell-color: rgba(184, 27, 68);
+@sell-color: rgba(184, 27, 68, 1);
 @sell-color-background: rgba(184, 27, 68, 0.4);
 
-@buy-color: rgba(12, 179, 130);
+@buy-color: rgba(12, 179, 130, 1);
 @buy-color-background: rgba(12, 179, 130, 0.4);


### PR DESCRIPTION
Fixes #303 

# Description

Display zero volume items

# Testing

Open widget settings and enable
![image](https://user-images.githubusercontent.com/29191749/177690647-db01992a-6f64-4b69-9527-f730a43b446a.png)

Check orderbook.

Open widget settings and enable 
![image](https://user-images.githubusercontent.com/29191749/177690664-c85555e5-57e7-4b6a-b2f8-1b032d32939d.png)
Check orderbook.

# Risk

No major changes

# Do you agree with those?
- [x] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [x] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
