### PR TITLE
add tooltips to table columns in blotter

### DIFF
--- a/src/app/modules/blotter/components/orders/orders.component.html
+++ b/src/app/modules/blotter/components/orders/orders.component.html
@@ -22,7 +22,7 @@
           [nzFilters]="column.listOfFilter"
           [nzShowFilter]="column.hasFilter"
           [nzFilterFn]="column.filterFn">
-        {{column.name}}
+        <span nz-tooltip [nzTooltipTitle]="column.tooltip">{{column.name}}</span>
         <nz-filter-trigger *ngIf='column.hasSearch' [(nzVisible)]="column.isSearchVisible" [nzActive]="!!searchFilter" [nzDropdownMenu]="searchMenu">
           <i [ngClass]="isFilterApplied(column) ? 'active-filter' : 'not-active-filter'" nz-icon nzType="search"></i>
         </nz-filter-trigger>

--- a/src/app/modules/blotter/components/orders/orders.component.ts
+++ b/src/app/modules/blotter/components/orders/orders.component.ts
@@ -73,6 +73,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Идентификационный номер заявки'
     },
     {
       id: 'symbol',
@@ -87,6 +88,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Биржевой идентификатор ценной бумаги'
     },
     {
       id: 'side',
@@ -103,6 +105,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Сторона заявки (покупка/продажа)'
     },
     {
       id: 'residue',
@@ -116,6 +119,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Отношение невыполненных заявок к общему количеству'
     },
     {
       id: 'volume',
@@ -129,6 +133,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Объем'
     },
     {
       id: 'qty',
@@ -142,6 +147,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество заявок'
     },
     {
       id: 'price',
@@ -172,6 +178,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Стаус заявки'
     },
     {
       id: 'transTime',
@@ -185,6 +192,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Время совершения заявки'
     },
     {
       id: 'exchange',
@@ -201,6 +209,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Наименование биржи'
     },
     {
       id: 'type',
@@ -217,6 +226,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Тип заявки (лимитная/рыночная)'
     },
     {
       id: 'endTime',
@@ -230,6 +240,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Срок действия заявки'
     },
   ];
   listOfColumns: Column<DisplayOrder, OrderFilter>[] = [];

--- a/src/app/modules/blotter/components/orders/orders.component.ts
+++ b/src/app/modules/blotter/components/orders/orders.component.ts
@@ -161,6 +161,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Цена заявки'
     },
     {
       id: 'status',

--- a/src/app/modules/blotter/components/positions/positions.component.html
+++ b/src/app/modules/blotter/components/positions/positions.component.html
@@ -21,7 +21,7 @@
           [nzFilters]="column.listOfFilter"
           [nzShowFilter]="column.hasFilter"
           [nzFilterFn]="column.filterFn">
-        {{column.name}}
+        <span nz-tooltip [nzTooltipTitle]="column.tooltip">{{column.name}}</span>
         <nz-filter-trigger *ngIf='column.hasSearch' [(nzVisible)]="column.isSearchVisible" [nzActive]="!!searchFilter" [nzDropdownMenu]="searchMenu">
           <i [ngClass]="isFilterApplied(column) ? 'active-filter' : 'not-active-filter'" nz-icon nzType="search"></i>
         </nz-filter-trigger>

--- a/src/app/modules/blotter/components/positions/positions.component.ts
+++ b/src/app/modules/blotter/components/positions/positions.component.ts
@@ -72,6 +72,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Биржевой идентификатор ценной бумаги'
     },
     {
       id: 'shortName',
@@ -86,6 +87,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Наименование позиции'
     },
     {
       id: 'avgPrice',
@@ -99,6 +101,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Средняя цена'
     },
     {
       id: 'qtyT0',
@@ -112,6 +115,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество позиций с учётом сегодняшних расчёов'
     },
     {
       id: 'qtyT1',
@@ -125,6 +129,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество позиций с учётом завтрашних расчёов'
     },
     {
       id: 'qtyT2',
@@ -138,6 +143,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество позиций с учётом послезавтрашних расчёов'
     },
     {
       id: 'qtyTFuture',
@@ -151,6 +157,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество позиций с учётом всех заявок'
     },
     {
       id: 'volume',
@@ -164,6 +171,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Объём'
     },
     {
       id: 'unrealisedPl',
@@ -177,6 +185,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Соотношение прибыли и убытка'
     },
     {
       id: 'dailyUnrealisedPl',
@@ -190,6 +199,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Соотношение прибыли и убытка за сегодня'
     },
   ];
   listOfColumns: Column<PositionDisplay, PositionFilter>[] = [];

--- a/src/app/modules/blotter/components/stop-orders/stop-orders.component.html
+++ b/src/app/modules/blotter/components/stop-orders/stop-orders.component.html
@@ -22,7 +22,7 @@
           [nzFilters]="column.listOfFilter"
           [nzShowFilter]="column.hasFilter"
           [nzFilterFn]="column.filterFn">
-        {{column.name}}
+        <span nz-tooltip [nzTooltipTitle]="column.tooltip">{{column.name}}</span>
         <nz-filter-trigger *ngIf='column.hasSearch' [(nzVisible)]="column.isSearchVisible" [nzActive]="!!searchFilter" [nzDropdownMenu]="searchMenu">
           <i [ngClass]="isFilterApplied(column) ? 'active-filter' : 'not-active-filter'"  nz-icon nzType="search"></i>
         </nz-filter-trigger>

--- a/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
+++ b/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
@@ -73,6 +73,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Идентификационный номер заявки'
     },
     {
       id: 'symbol',
@@ -87,6 +88,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Биржевой идентификатор ценной бумаги'
     },
     {
       id: 'side',
@@ -103,6 +105,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Сторона заявки (покупка/продажа)'
     },
     {
       id: 'residue',
@@ -116,6 +119,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Отношение невыполненных заявок к общему количеству'
     },
     {
       id: 'volume',
@@ -129,6 +133,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Объем'
     },
     {
       id: 'qty',
@@ -142,6 +147,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество заявок'
     },
     {
       id: 'price',
@@ -155,6 +161,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Цена'
     },
     {
       id: 'triggerPrice',
@@ -168,6 +175,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Сигнальная цена (заявка выставится, когда цена упадёт/поднимется до указанного значения)'
     },
     {
       id: 'status',
@@ -185,6 +193,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Стаус заявки'
     },
     {
       id: 'conditionType',
@@ -201,6 +210,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Условие, при котором будет выставлена заявка'
     },
     {
       id: 'transTime',
@@ -214,6 +224,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Время совершения заявки'
     },
     {
       id: 'exchange',
@@ -230,6 +241,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Наименование биржи'
     },
     {
       id: 'type',
@@ -246,6 +258,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Тип заявки (лимитная/рыночная)'
     },
     {
       id: 'endTime',
@@ -259,6 +272,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Срок действия заявки'
     },
   ];
   listOfColumns: Column<DisplayOrder, OrderFilter>[] = [];

--- a/src/app/modules/blotter/components/trades/trades.component.html
+++ b/src/app/modules/blotter/components/trades/trades.component.html
@@ -20,7 +20,7 @@
           [nzFilters]="column.listOfFilter"
           [nzShowFilter]="column.hasFilter"
           [nzFilterFn]="column.filterFn">
-        {{column.name}}
+        <span nz-tooltip [nzTooltipTitle]="column.tooltip">{{column.name}}</span>
         <nz-filter-trigger *ngIf='column.hasSearch' [(nzVisible)]="column.isSearchVisible" [nzActive]="!!searchFilter" [nzDropdownMenu]="searchMenu">
           <i [ngClass]="isFilterApplied(column) ? 'active-filter' : 'not-active-filter'"  nz-icon nzType="search"></i>
         </nz-filter-trigger>

--- a/src/app/modules/blotter/components/trades/trades.component.ts
+++ b/src/app/modules/blotter/components/trades/trades.component.ts
@@ -69,6 +69,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Идентификационный номер сделки'
     },
     {
       id: 'orderno',
@@ -83,6 +84,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Номер заявки'
     },
     {
       id: 'symbol',
@@ -97,6 +99,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Биржевой идентификатор ценной бумаги'
     },
     {
       id: 'side',
@@ -108,11 +111,12 @@ export class TradesComponent implements OnInit, OnDestroy {
       hasSearch: false,
       filterFn: (list: string[], trade: DisplayTrade) => list.some(val => trade.side.toString().indexOf(val) !== -1),
       listOfFilter: [
-        { text: 'Покупка', value: 'buy' },
-        { text: 'Продажа', value: 'sell' }
+        {text: 'Покупка', value: 'buy'},
+        {text: 'Продажа', value: 'sell'}
       ],
       isFilterVisible: false,
       hasFilter: true,
+      tooltip: 'Сторона сделки (покупка/продажа)'
     },
     {
       id: 'qty',
@@ -126,6 +130,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Количество сделок'
     },
     {
       id: 'price',
@@ -139,6 +144,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Цена'
     },
     {
       id: 'date',
@@ -152,6 +158,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Время совершения сделки'
     },
     {
       id: 'volume',
@@ -165,6 +172,7 @@ export class TradesComponent implements OnInit, OnDestroy {
       listOfFilter: [],
       isFilterVisible: false,
       hasFilter: false,
+      tooltip: 'Объём'
     },
   ];
   listOfColumns: Column<DisplayTrade, TradeFilter>[] = [];

--- a/src/app/modules/blotter/models/column.model.ts
+++ b/src/app/modules/blotter/models/column.model.ts
@@ -1,19 +1,20 @@
 import { NzTableFilterFn, NzTableFilterList, NzTableSortFn, NzTableSortOrder } from 'ng-zorro-antd/table';
 
 export interface Column<T, F> {
-  id: string,
+  id: string;
   name: string;
   // sorting
   sortOrder: NzTableSortOrder | null;
   sortFn: NzTableSortFn<T> | null;
   // search with test
-  searchDescription?: string,
-  searchFn: ((order: T, filter: F) => boolean) | null,
-  isSearchVisible: boolean,
-  hasSearch: boolean
+  searchDescription?: string;
+  searchFn: ((order: T, filter: F) => boolean) | null;
+  isSearchVisible: boolean;
+  hasSearch: boolean;
   // filter from existing values
   listOfFilter: NzTableFilterList;
   filterFn: NzTableFilterFn<T> | null;
-  isFilterVisible: boolean,
-  hasFilter: boolean,
+  isFilterVisible: boolean;
+  hasFilter: boolean;
+  tooltip?: string;
 }


### PR DESCRIPTION
Fixes  #373 

# Description

add tooltips to table columns in blotter

# Testing

open blotter widget
go to orders/stop-orders/trades/positions tab
hover mouse on table header

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
