### PR TITLE
add multiple binding widgets to instruments select

### DIFF
--- a/src/app/modules/all-instruments/components/all-instruments/all-instruments.component.ts
+++ b/src/app/modules/all-instruments/components/all-instruments/all-instruments.component.ts
@@ -10,6 +10,7 @@ import { Store } from "@ngrx/store";
 import { selectNewInstrumentByBadge } from "../../../../store/instruments/instruments.actions";
 import { WatchlistCollectionService } from "../../../instruments/services/watchlist-collection.service";
 import { ContextMenu } from "../../../../shared/models/infinite-scroll-table.model";
+import { defaultBadgeColor } from "../../../../shared/utils/instruments";
 
 @Component({
   selector: 'ats-all-instruments',
@@ -23,7 +24,7 @@ export class AllInstrumentsComponent implements OnInit, OnDestroy {
     limit: 50,
     offset: 0
   };
-  private badgeColor = 'white';
+  private badgeColor = defaultBadgeColor;
 
   @Input() guid!: string;
   @Input() contentSize!: DashboardItemContentSize | null;

--- a/src/app/modules/all-instruments/components/all-instruments/all-instruments.component.ts
+++ b/src/app/modules/all-instruments/components/all-instruments/all-instruments.component.ts
@@ -7,7 +7,7 @@ import { WidgetSettingsService } from "../../../../shared/services/widget-settin
 import { AllInstrumentsSettings } from "../../../../shared/models/settings/all-instruments-settings.model";
 import { AllInstruments, AllInstrumentsFilters } from "../../model/all-instruments.model";
 import { Store } from "@ngrx/store";
-import { selectNewInstrument } from "../../../../store/instruments/instruments.actions";
+import { selectNewInstrumentByBadge } from "../../../../store/instruments/instruments.actions";
 import { WatchlistCollectionService } from "../../../instruments/services/watchlist-collection.service";
 import { ContextMenu } from "../../../../shared/models/infinite-scroll-table.model";
 
@@ -23,6 +23,7 @@ export class AllInstrumentsComponent implements OnInit, OnDestroy {
     limit: 50,
     offset: 0
   };
+  private badgeColor = 'white';
 
   @Input() guid!: string;
   @Input() contentSize!: DashboardItemContentSize | null;
@@ -100,6 +101,7 @@ export class AllInstrumentsComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(settings => {
         this.displayedColumns = this.allColumns.filter(col => settings.allInstrumentsColumns.includes(col.name));
+        this.badgeColor = settings.badgeColor!;
       });
 
     this.watchlistCollectionService.collectionChanged$
@@ -143,7 +145,7 @@ export class AllInstrumentsComponent implements OnInit, OnDestroy {
       symbol: row.name,
       exchange: row.exchange,
     };
-    this.store.dispatch(selectNewInstrument({instrument}));
+    this.store.dispatch(selectNewInstrumentByBadge({instrument, badgeColor: this.badgeColor}));
   }
 
   initContextMenu() {

--- a/src/app/modules/blotter/components/orders/orders.component.ts
+++ b/src/app/modules/blotter/components/orders/orders.component.ts
@@ -34,6 +34,7 @@ import { BlotterSettings } from "../../../../shared/models/settings/blotter-sett
 import { ExportHelper } from "../../utils/export-helper";
 import { NzTableComponent } from 'ng-zorro-antd/table';
 import { isEqualBlotterSettings } from "../../../../shared/utils/settings-helper";
+import { defaultBadgeColor } from "../../../../shared/utils/instruments";
 
 interface DisplayOrder extends Order {
   residue: string,
@@ -251,7 +252,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
   private orders: Order[] = [];
   private orders$: Observable<Order[]> = of([]);
   private settings$!: Observable<BlotterSettings>;
-  private badgeColor = 'white';
+  private badgeColor = defaultBadgeColor;
 
   constructor(
     private readonly settingsService: WidgetSettingsService,

--- a/src/app/modules/blotter/components/orders/orders.component.ts
+++ b/src/app/modules/blotter/components/orders/orders.component.ts
@@ -251,6 +251,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
   private orders: Order[] = [];
   private orders$: Observable<Order[]> = of([]);
   private settings$!: Observable<BlotterSettings>;
+  private badgeColor = 'white';
 
   constructor(
     private readonly settingsService: WidgetSettingsService,
@@ -273,6 +274,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
         this.listOfColumns = this.allColumns.filter(c => s.ordersColumns.includes(c.id));
         this.tableInnerWidth = `${this.listOfColumns.length * 100}px`;
       }
+      this.badgeColor = s.badgeColor!;
     });
 
     this.orders$ = this.settings$.pipe(
@@ -383,7 +385,7 @@ export class OrdersComponent implements OnInit, OnDestroy {
   }
 
   selectInstrument(symbol: string, exchange: string) {
-    this.service.selectNewInstrument(symbol, exchange);
+    this.service.selectNewInstrument(symbol, exchange, this.badgeColor);
   }
 
   isFilterApplied(column: Column<DisplayOrder, OrderFilter>) {

--- a/src/app/modules/blotter/components/positions/positions.component.ts
+++ b/src/app/modules/blotter/components/positions/positions.component.ts
@@ -57,6 +57,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
   isFilterDisabled = () => Object.keys(this.searchFilter.getValue()).length === 0;
 
   private settings$!: Observable<BlotterSettings>;
+  private badgeColor = 'white';
 
   allColumns: Column<PositionDisplay, PositionFilter>[] = [
     {
@@ -221,6 +222,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
           this.listOfColumns = this.allColumns.filter(c => s.positionsColumns.includes(c.id));
           this.tableInnerWidth = `${this.listOfColumns.length * 100}px`;
         }
+        this.badgeColor = s.badgeColor!;
       }
     );
 
@@ -272,7 +274,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
   }
 
   selectInstrument(symbol: string, exchange: string) {
-    this.service.selectNewInstrument(symbol, exchange);
+    this.service.selectNewInstrument(symbol, exchange, this.badgeColor);
   }
 
   isFilterApplied(column: Column<PositionDisplay, PositionFilter>) {

--- a/src/app/modules/blotter/components/positions/positions.component.ts
+++ b/src/app/modules/blotter/components/positions/positions.component.ts
@@ -32,6 +32,7 @@ import { BlotterSettings } from "../../../../shared/models/settings/blotter-sett
 import { NzTableComponent } from 'ng-zorro-antd/table';
 import { ExportHelper } from "../../utils/export-helper";
 import { isEqualBlotterSettings } from "../../../../shared/utils/settings-helper";
+import { defaultBadgeColor } from "../../../../shared/utils/instruments";
 
 interface PositionDisplay extends Position {
   volume: number
@@ -57,7 +58,7 @@ export class PositionsComponent implements OnInit, OnDestroy {
   isFilterDisabled = () => Object.keys(this.searchFilter.getValue()).length === 0;
 
   private settings$!: Observable<BlotterSettings>;
-  private badgeColor = 'white';
+  private badgeColor = defaultBadgeColor;
 
   allColumns: Column<PositionDisplay, PositionFilter>[] = [
     {

--- a/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
+++ b/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
@@ -34,6 +34,7 @@ import { BlotterSettings } from "../../../../shared/models/settings/blotter-sett
 import { NzTableComponent } from 'ng-zorro-antd/table';
 import { ExportHelper } from "../../utils/export-helper";
 import { isEqualBlotterSettings } from "../../../../shared/utils/settings-helper";
+import { defaultBadgeColor } from "../../../../shared/utils/instruments";
 
 interface DisplayOrder extends StopOrder {
   residue: string,
@@ -281,7 +282,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
   private cancels$ = this.cancelCommands.asObservable();
   private orders: StopOrder[] = [];
   private settings$!: Observable<BlotterSettings>;
-  private badgeColor = 'white';
+  private badgeColor = defaultBadgeColor;
 
   constructor(
     private readonly service: BlotterService,

--- a/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
+++ b/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
@@ -281,6 +281,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
   private cancels$ = this.cancelCommands.asObservable();
   private orders: StopOrder[] = [];
   private settings$!: Observable<BlotterSettings>;
+  private badgeColor = 'white';
 
   constructor(
     private readonly service: BlotterService,
@@ -304,6 +305,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
         this.listOfColumns = this.allColumns.filter(c => s.stopOrdersColumns.includes(c.id));
         this.tableInnerWidth = `${this.listOfColumns.length * 100}px`;
       }
+      this.badgeColor = s.badgeColor!;
     });
 
     const orders$ = this.settings$.pipe(
@@ -417,7 +419,7 @@ export class StopOrdersComponent implements OnInit, OnDestroy {
   }
 
   selectInstrument(symbol: string, exchange: string) {
-    this.service.selectNewInstrument(symbol, exchange);
+    this.service.selectNewInstrument(symbol, exchange, this.badgeColor);
   }
 
   isFilterApplied(column: Column<DisplayOrder, OrderFilter>) {

--- a/src/app/modules/blotter/services/blotter.service.ts
+++ b/src/app/modules/blotter/services/blotter.service.ts
@@ -30,9 +30,9 @@ import { WebsocketService } from 'src/app/shared/services/websocket.service';
 import { formatCurrency } from 'src/app/shared/utils/formatters';
 import { CommonSummaryView } from '../models/common-summary-view.model';
 import { CommonSummaryModel } from '../models/common-summary.model';
-import { selectNewInstrument } from '../../../store/instruments/instruments.actions';
 import { ForwardRisks } from "../models/forward-risks.model";
 import { ForwardRisksView } from "../models/forward-risks-view.model";
+import { selectNewInstrumentByBadge } from "../../../store/instruments/instruments.actions";
 
 @Injectable({
   providedIn: 'root'
@@ -51,7 +51,7 @@ export class BlotterService extends BaseWebsocketService {
     super(ws);
   }
 
-  selectNewInstrument(symbol: string, exchange: string) {
+  selectNewInstrument(symbol: string, exchange: string, badgeColor: string) {
     if (symbol == CurrencyCode.RUB) {
       return;
     }
@@ -60,7 +60,7 @@ export class BlotterService extends BaseWebsocketService {
       exchange = Exchanges.MOEX;
     }
     const instrument = { symbol, exchange, instrumentGroup: undefined };
-    this.store.dispatch(selectNewInstrument({ instrument }));
+    this.store.dispatch(selectNewInstrumentByBadge({ instrument, badgeColor }));
   }
 
   getPositions(settings: BlotterSettings) {

--- a/src/app/modules/dashboard/components/navbar/navbar.component.ts
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.ts
@@ -10,10 +10,10 @@ import { Instrument } from 'src/app/shared/models/instruments/instrument.model';
 import { CommandType } from 'src/app/shared/models/enums/command-type.model';
 import { ModalService } from 'src/app/shared/services/modal.service';
 import { Store } from '@ngrx/store';
-import { getSelectedInstrument } from '../../../../store/instruments/instruments.selectors';
 import { selectNewPortfolio } from '../../../../store/portfolios/portfolios.actions';
 import { joyrideContent } from '../../models/joyride';
 import { PortfolioExtended } from 'src/app/shared/models/user/portfolio-extended.model';
+import { getSelectedInstrumentByBadge } from "../../../../store/instruments/instruments.selectors";
 
 @Component({
   selector: 'ats-navbar',
@@ -47,7 +47,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
       this.changePortfolio(this.selectDefault(portfolios));
     });
 
-    this.activeInstrument$ = this.store.select(getSelectedInstrument);
+    this.activeInstrument$ = this.store.select(getSelectedInstrumentByBadge('white'));
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.html
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.html
@@ -9,7 +9,10 @@
   </button>
   <label class="title">
     <nz-badge
-      *ngIf="s.badgeColor && (terminalSettings$ | async)?.badgesBind; else textTitle"
+      *ngIf="s.badgeColor &&
+        (terminalSettings$ | async)?.badgesBind &&
+        (s.linkToActive || ['InstrumentSelectSettings', 'BlotterSettings', 'AllInstrumentsSettings'].includes(s.settingsType!));
+        else textTitle"
       nz-dropdown
       [nzDropdownMenu]="badgesMenu"
       [nzColor]="s.badgeColor"

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.html
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.html
@@ -7,7 +7,26 @@
       [title]="joyrideContent.step8.title"
       [text]="joyrideContent.step8.text"></i>
   </button>
-  <label class="title">{{s.title}}</label>
+  <label class="title">
+    <nz-badge
+      *ngIf="s.badgeColor && (terminalSettings$ | async)?.badgesBind; else textTitle"
+      nz-dropdown
+      [nzDropdownMenu]="badgesMenu"
+      [nzColor]="s.badgeColor"
+      [nzText]="s.title"
+    ></nz-badge>
+    <ng-template #textTitle>
+      {{s.title}}
+    </ng-template>
+
+    <nz-dropdown-menu #badgesMenu="nzDropdownMenu">
+      <ul nz-menu class="badge-menu">
+        <li nz-menu-item *ngFor="let badge of badges" (click)="switchBadgeColor(badge)">
+          <nz-badge [nzColor]="badge"></nz-badge>
+        </li>
+      </ul>
+    </nz-dropdown-menu>
+  </label>
   <span>
     <button *ngIf='s.linkToActive !== undefined' nz-button nzSize="small"
       (mousedown)="linkToActive($event, !s.linkToActive)"

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.less
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.less
@@ -39,3 +39,7 @@ button {
     color: lightgreen;
   }
 }
+
+.badge-menu {
+  width: fit-content;
+}

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.spec.ts
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.spec.ts
@@ -1,20 +1,26 @@
 import {
-  ComponentFixture,
-  TestBed
+  ComponentFixture, fakeAsync,
+  TestBed, tick
 } from '@angular/core/testing';
 
 import { WidgetHeaderComponent } from './widget-header.component';
 import { DashboardService } from 'src/app/shared/services/dashboard.service';
 import { ModalService } from 'src/app/shared/services/modal.service';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
 import { ngZorroMockComponents } from "../../../../shared/utils/testing";
+import { TerminalSettingsService } from "../../../terminal-settings/services/terminal-settings.service";
+import { By } from "@angular/platform-browser";
 
 describe('WidgetHeaderComponent', () => {
   let component: WidgetHeaderComponent;
   let fixture: ComponentFixture<WidgetHeaderComponent>;
   let spy = jasmine.createSpyObj('DashboardService', ['removeWidget']);
   let modalSpy = jasmine.createSpyObj('ModalService', ['openHelpModal']);
+  const terminalSettingsSub = new Subject();
+  let terminalSettingsSpy = {
+    getSettings: jasmine.createSpy('getSettings').and.returnValue(terminalSettingsSub)
+  };
 
   beforeAll(() => TestBed.resetTestingModule());
   beforeEach(async () => {
@@ -27,11 +33,13 @@ describe('WidgetHeaderComponent', () => {
         {
           provide: WidgetSettingsService,
           useValue: {
-            getSettings: jasmine.createSpy('getSettings').and.returnValue(of({}))
+            getSettings: jasmine.createSpy('getSettings').and.returnValue(of({ badgeColor: 'yellow', guid: 'testGuid' })),
+            updateSettings: jasmine.createSpy('updateSettings').and.callThrough()
           }
         },
         { provide: DashboardService, useValue: spy },
-        { provide: ModalService, useValue: modalSpy }
+        { provide: ModalService, useValue: modalSpy },
+        { provide: TerminalSettingsService, useValue: terminalSettingsSpy }
       ]
     }).compileComponents();
   });
@@ -46,5 +54,28 @@ describe('WidgetHeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show badge in dependence of terminal settings', fakeAsync(() => {
+    terminalSettingsSub.next({badgesBind: false});
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('nz-badge[nz-dropdown]'))).toBeFalsy();
+
+    terminalSettingsSub.next({badgesBind: true});
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('nz-badge[nz-dropdown]'))).toBeTruthy();
+  }));
+
+  it('should change badge color', () => {
+    const switchBadgeColorSpy = spyOn(component, 'switchBadgeColor').and.callThrough();
+
+    terminalSettingsSub.next({badgesBind: true});
+    fixture.debugElement.queryAll(By.css('.badge-menu li'))[1].triggerEventHandler('click', {});
+
+    expect(switchBadgeColorSpy).toHaveBeenCalledOnceWith('blue');
   });
 });

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.spec.ts
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.spec.ts
@@ -33,7 +33,7 @@ describe('WidgetHeaderComponent', () => {
         {
           provide: WidgetSettingsService,
           useValue: {
-            getSettings: jasmine.createSpy('getSettings').and.returnValue(of({ badgeColor: 'yellow', guid: 'testGuid' })),
+            getSettings: jasmine.createSpy('getSettings').and.returnValue(of({ badgeColor: 'yellow', guid: 'testGuid', linkToActive: true })),
             updateSettings: jasmine.createSpy('updateSettings').and.callThrough()
           }
         },

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.ts
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.ts
@@ -21,6 +21,9 @@ import {
 import { AnySettings } from '../../../../shared/models/settings/any-settings.model';
 import { joyrideContent } from '../../models/joyride';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
+import { instrumentsBadges } from "../../../../shared/utils/instruments";
+import { TerminalSettingsService } from "../../../terminal-settings/services/terminal-settings.service";
+import { TerminalSettings } from "../../../../shared/models/terminal-settings/terminal-settings.model";
 
 
 @Component({
@@ -44,14 +47,19 @@ export class WidgetHeaderComponent implements OnInit {
 
   joyrideContent = joyrideContent;
   settings$!: Observable<AnySettings>;
+  terminalSettings$!: Observable<TerminalSettings>;
+  badges = instrumentsBadges;
 
   constructor(
     private readonly settingsService: WidgetSettingsService,
     private readonly dashboardService: DashboardService,
-    private readonly modal: ModalService) {
+    private readonly modal: ModalService,
+    private readonly terminalSettingsService: TerminalSettingsService
+  ) {
   }
 
   ngOnInit() {
+    this.terminalSettings$ = this.terminalSettingsService.getSettings();
     this.settings$ = this.settingsService.getSettings(this.guid).pipe(
       map(s => {
         const settings = {
@@ -98,5 +106,9 @@ export class WidgetHeaderComponent implements OnInit {
       const name = getTypeBySettings(settings);
       this.modal.openHelpModal(name);
     });
+  }
+
+  switchBadgeColor(badgeColor: string) {
+    this.settingsService.updateSettings(this.guid, { badgeColor });
   }
 }

--- a/src/app/modules/instruments/components/instrument-select/instrument-select.component.ts
+++ b/src/app/modules/instruments/components/instrument-select/instrument-select.component.ts
@@ -20,13 +20,12 @@ import {
 import {
   debounceTime,
   filter,
-  map,
   switchMap
 } from 'rxjs/operators';
 import { Instrument } from 'src/app/shared/models/instruments/instrument.model';
 import { SearchFilter } from '../../models/search-filter.model';
 import { InstrumentsService } from '../../services/instruments.service';
-import { selectNewInstrument } from '../../../../store/instruments/instruments.actions';
+import { selectNewInstrumentByBadge } from '../../../../store/instruments/instruments.actions';
 import { InstrumentKey } from '../../../../shared/models/instruments/instrument-key.model';
 import { WatchlistCollectionService } from '../../services/watchlist-collection.service';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
@@ -93,7 +92,6 @@ export class InstrumentSelectComponent implements OnInit {
 
   onSelect(event: NzOptionSelectionChange, val: Instrument) {
     if (event.isUserInput) {
-      this.store.dispatch(selectNewInstrument({ instrument: val }));
       this.watch(val);
       setTimeout(() => {
         this.inputEl.nativeElement.value = '';
@@ -112,13 +110,13 @@ export class InstrumentSelectComponent implements OnInit {
     this.setDefaultWatchList();
   }
 
-  watch(inst: InstrumentKey) {
+  watch(instrument: InstrumentKey) {
     this.settingsService.getSettings<InstrumentSelectSettings>(this.guid).pipe(
-      map(s => s.activeListId),
-      filter((id): id is string => !!id),
+      filter(({activeListId}) => !!activeListId),
       take(1)
-    ).subscribe(activeListId => {
-      this.watchlistCollectionService.addItemsToList(activeListId, [inst]);
+    ).subscribe(s => {
+      this.watchlistCollectionService.addItemsToList(s.activeListId!, [instrument]);
+      this.store.dispatch(selectNewInstrumentByBadge({ badgeColor: s.badgeColor!, instrument }));
     });
   }
 

--- a/src/app/modules/instruments/components/watchlist-table/watchlist-table.component.ts
+++ b/src/app/modules/instruments/components/watchlist-table/watchlist-table.component.ts
@@ -13,7 +13,7 @@ import {
 } from 'rxjs';
 import { WatchedInstrument } from '../../models/watched-instrument.model';
 import { WatchInstrumentsService } from '../../services/watch-instruments.service';
-import { selectNewInstrument } from '../../../../store/instruments/instruments.actions';
+import { selectNewInstrumentByBadge } from '../../../../store/instruments/instruments.actions';
 import { InstrumentKey } from '../../../../shared/models/instruments/instrument-key.model';
 import { WatchlistCollectionService } from '../../services/watchlist-collection.service';
 import {
@@ -42,6 +42,7 @@ export class WatchlistTableComponent implements OnInit {
 
   watchedInstruments$: Observable<WatchedInstrument[]> = of([]);
   displayedColumns: ColumnIds[] = [];
+  badgeColor: string = '';
 
   sortFns: { [keyName: string]: (a: InstrumentKey, b: InstrumentKey) => number } = {
     symbol: this.getSortFn('instrument.symbol'),
@@ -79,13 +80,14 @@ export class WatchlistTableComponent implements OnInit {
     this.watchedInstruments$ = this.settingsService.getSettings<InstrumentSelectSettings>(this.guid).pipe(
       tap(settings => {
         this.displayedColumns = allInstrumentsColumns.filter(c => settings.instrumentColumns.includes(c.columnId));
+        this.badgeColor = settings.badgeColor!;
       }),
       switchMap(settings => this.watchInstrumentsService.getWatched(settings)),
     );
   }
 
   makeActive(instrument: InstrumentKey) {
-    this.store.dispatch(selectNewInstrument({ instrument }));
+    this.store.dispatch(selectNewInstrumentByBadge({ instrument, badgeColor: this.badgeColor }));
   }
 
   remove(instr: InstrumentKey) {

--- a/src/app/modules/terminal-settings/components/terminal-settings/terminal-settings.component.html
+++ b/src/app/modules/terminal-settings/components/terminal-settings/terminal-settings.component.html
@@ -46,6 +46,14 @@
               formControlName="badgesBind"
             >
               Включить привязку инструментов к лейблам
+              <span
+                nz-icon
+                nz-popover
+                nzPopoverTitle="В заголовках виджетов появятся цветные бейджи"
+                nzPopoverContent="Выбрав инструмент в виджете с бейджем определённого цвета, поменяется выбранный инструмент во всех виджетах с бейджем этого же цвета"
+                nzType="info-circle"
+                nzTheme="outline">
+              </span>
             </label>
           </nz-form-item>
 

--- a/src/app/modules/terminal-settings/components/terminal-settings/terminal-settings.component.html
+++ b/src/app/modules/terminal-settings/components/terminal-settings/terminal-settings.component.html
@@ -40,6 +40,15 @@
               </nz-form-control>
             </nz-form-item>
 
+          <nz-form-item>
+            <label
+              nz-checkbox
+              formControlName="badgesBind"
+            >
+              Включить привязку инструментов к лейблам
+            </label>
+          </nz-form-item>
+
             <h2>Горячие клавиши</h2>
             <h3>Общие для всех открытых стаканов</h3>
 

--- a/src/app/modules/terminal-settings/components/terminal-settings/terminal-settings.component.ts
+++ b/src/app/modules/terminal-settings/components/terminal-settings/terminal-settings.component.ts
@@ -117,6 +117,7 @@ export class TerminalSettingsComponent implements OnInit {
           Validators.min(this.validationSettings.userIdleDurationMin.min),
           Validators.max(this.validationSettings.userIdleDurationMin.max)
         ]),
+      badgesBind: new FormControl(currentSettings.badgesBind),
       hotKeysSettings: new FormGroup({
         cancelOrdersKey: new FormControl(currentSettings.hotKeysSettings?.cancelOrdersKey),
         closePositionsKey: new FormControl(currentSettings.hotKeysSettings?.closePositionsKey),

--- a/src/app/shared/models/instruments/instrument.model.ts
+++ b/src/app/shared/models/instruments/instrument.model.ts
@@ -11,3 +11,7 @@ export interface Instrument extends InstrumentKey {
   cfiCode?: string,
   type?: string
 }
+
+export interface InstrumentBadges {
+  [badgeColor: string]: Instrument
+}

--- a/src/app/shared/models/terminal-settings/terminal-settings.model.ts
+++ b/src/app/shared/models/terminal-settings/terminal-settings.model.ts
@@ -17,5 +17,6 @@ export interface HotKeysSettings {
 export interface TerminalSettings {
   timezoneDisplayOption?: TimezoneDisplayOption;
   userIdleDurationMin?: number;
+  badgesBind?: boolean;
   hotKeysSettings?: HotKeysSettings;
 }

--- a/src/app/shared/models/widget-settings.model.ts
+++ b/src/app/shared/models/widget-settings.model.ts
@@ -2,5 +2,6 @@ export interface WidgetSettings {
   title?: string,
   guid: string,
   linkToActive?: boolean
-  settingsType?: string
+  settingsType?: string;
+  badgeColor?: string;
 }

--- a/src/app/shared/services/widget-factory.service.ts
+++ b/src/app/shared/services/widget-factory.service.ts
@@ -35,7 +35,7 @@ import { ExchangeRateSettings } from "../models/settings/exchange-rate-settings.
 import { ScalperOrderBookSettings } from "../models/settings/scalper-order-book-settings.model";
 import { TechChartSettings } from "../models/settings/tech-chart-settings.model";
 import { AllInstrumentsSettings, allInstrumentsColumns as allInstrumentsCols } from "../models/settings/all-instruments-settings.model";
-import { instrumentsBadges } from "../utils/instruments";
+import { defaultBadgeColor, instrumentsBadges } from "../utils/instruments";
 
 @Injectable({
   providedIn: 'root',
@@ -116,7 +116,7 @@ export class WidgetFactoryService {
       guid: newWidget.gridItem.label,
       settingsType: 'OrderbookSettings',
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       depth: 10,
       title: `Стакан`,
       showChart: true,
@@ -136,7 +136,7 @@ export class WidgetFactoryService {
       settingsType: 'ScalperOrderBookSettings',
       title: `Скальперский стакан`,
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       depth: 10,
       showYieldForBonds: false,
       showZeroVolumeItems: false,
@@ -159,7 +159,7 @@ export class WidgetFactoryService {
       settingsType: 'InstrumentSelectSettings',
       title: `Выбор инструмента`,
       instrumentColumns: allInstrumentsColumns.filter(c => c.isDefault).map(c => c.columnId),
-      badgeColor: 'yellow'
+      badgeColor: defaultBadgeColor
     } as InstrumentSelectSettings;
   }
 
@@ -173,7 +173,7 @@ export class WidgetFactoryService {
     return {
       ...this.badges.yellow,
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       guid: newWidget.gridItem.label,
       settingsType: 'LightChartSettings',
       timeFrame: TimeframesHelper.getTimeframeByValue(TimeframeValue.Day)?.value,
@@ -199,7 +199,7 @@ export class WidgetFactoryService {
       ordersColumns: allOrdersColumns.filter(c => c.isDefault).map(c => c.columnId),
       stopOrdersColumns: allStopOrdersColumns.filter(c => c.isDefault).map(c => c.columnId),
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       title: `Блоттер`,
       isSoldPositionsHidden: true
     } as BlotterSettings;
@@ -215,7 +215,7 @@ export class WidgetFactoryService {
     return {
       ...this.badges.yellow,
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       guid: newWidget.gridItem.label,
       settingsType: 'InfoSettings',
       title: `Инфо`,
@@ -230,7 +230,7 @@ export class WidgetFactoryService {
     return {
       ...this.badges.yellow,
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       guid: newWidget.gridItem.label,
       settingsType: 'AllTradesSettings',
       title: `Все сделки`
@@ -272,7 +272,7 @@ export class WidgetFactoryService {
       settingsType: 'TechChartSettings',
       title: 'Тех. анализ',
       linkToActive: true,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       chartSettings: {}
     } as TechChartSettings;
   }
@@ -284,7 +284,7 @@ export class WidgetFactoryService {
 
     return {
       guid: newWidget.gridItem.label,
-      badgeColor: 'yellow',
+      badgeColor: defaultBadgeColor,
       settingsType: 'AllInstrumentsSettings',
       title: 'Все инструменты',
       allInstrumentsColumns: allInstrumentsCols.filter(c => c.isDefault).map(col => col.columnId)

--- a/src/app/shared/services/widget-factory.service.ts
+++ b/src/app/shared/services/widget-factory.service.ts
@@ -13,7 +13,7 @@ import {
   allInstrumentsColumns,
   InstrumentSelectSettings
 } from '../models/settings/instrument-select-settings.model';
-import { Instrument } from '../models/instruments/instrument.model';
+import { InstrumentBadges } from '../models/instruments/instrument.model';
 import {
   allOrdersColumns,
   allPositionsColumns,
@@ -26,7 +26,7 @@ import { WidgetNames } from '../models/enums/widget-names';
 import { CurrencyInstrument } from '../models/enums/currencies.model';
 import { InfoSettings } from '../models/settings/info-settings.model';
 import { Store } from '@ngrx/store';
-import { getSelectedInstrument } from '../../store/instruments/instruments.selectors';
+import { getSelectedInstrumentsWithBadges } from '../../store/instruments/instruments.selectors';
 import { getSelectedPortfolio } from '../../store/portfolios/portfolios.selectors';
 import { defaultInstrument } from '../../store/instruments/instruments.reducer';
 import { AllTradesSettings } from "../models/settings/all-trades-settings.model";
@@ -35,6 +35,7 @@ import { ExchangeRateSettings } from "../models/settings/exchange-rate-settings.
 import { ScalperOrderBookSettings } from "../models/settings/scalper-order-book-settings.model";
 import { TechChartSettings } from "../models/settings/tech-chart-settings.model";
 import { AllInstrumentsSettings, allInstrumentsColumns as allInstrumentsCols } from "../models/settings/all-instruments-settings.model";
+import { instrumentsBadges } from "../utils/instruments";
 
 @Injectable({
   providedIn: 'root',
@@ -42,15 +43,17 @@ import { AllInstrumentsSettings, allInstrumentsColumns as allInstrumentsCols } f
 export class WidgetFactoryService {
 
   // TODO: Make the method createNewSettings asynchronous to avoid the need for synchronization with local state
-  private selectedInstrument: Instrument = {
-    ...defaultInstrument
-  };
+  private badges: InstrumentBadges = instrumentsBadges
+    .reduce((acc, curr) => {
+      acc[curr] = {...defaultInstrument};
+      return acc;
+    }, {} as InstrumentBadges);
 
   private selectedPortfolio: PortfolioKey | null = null;
 
   constructor(private store: Store) {
-    this.store.select(getSelectedInstrument).subscribe(
-      (si) => (this.selectedInstrument = si)
+    this.store.select(getSelectedInstrumentsWithBadges).subscribe(
+      (si) => (this.badges = si)
     );
     this.store.select(getSelectedPortfolio).subscribe(
       (sp) => (this.selectedPortfolio = sp)
@@ -109,10 +112,11 @@ export class WidgetFactoryService {
     }
 
     return {
-      ...this.selectedInstrument,
+      ...this.badges.yellow,
       guid: newWidget.gridItem.label,
       settingsType: 'OrderbookSettings',
       linkToActive: true,
+      badgeColor: 'yellow',
       depth: 10,
       title: `Стакан`,
       showChart: true,
@@ -127,15 +131,13 @@ export class WidgetFactoryService {
     }
 
     return {
+      ...this.badges.yellow,
       guid: newWidget.gridItem.label,
       settingsType: 'ScalperOrderBookSettings',
       title: `Скальперский стакан`,
       linkToActive: true,
+      badgeColor: 'yellow',
       depth: 10,
-      symbol: this.selectedInstrument.symbol,
-      exchange: this.selectedInstrument.exchange,
-      instrumentGroup: this.selectedInstrument.instrumentGroup,
-      isin: this.selectedInstrument.isin,
       showYieldForBonds: false,
       showZeroVolumeItems: false,
       showSpreadItems: false,
@@ -156,7 +158,8 @@ export class WidgetFactoryService {
       guid: newWidget.gridItem.label,
       settingsType: 'InstrumentSelectSettings',
       title: `Выбор инструмента`,
-      instrumentColumns: allInstrumentsColumns.filter(c => c.isDefault).map(c => c.columnId)
+      instrumentColumns: allInstrumentsColumns.filter(c => c.isDefault).map(c => c.columnId),
+      badgeColor: 'yellow'
     } as InstrumentSelectSettings;
   }
 
@@ -168,8 +171,9 @@ export class WidgetFactoryService {
     }
 
     return {
-      ...this.selectedInstrument,
+      ...this.badges.yellow,
       linkToActive: true,
+      badgeColor: 'yellow',
       guid: newWidget.gridItem.label,
       settingsType: 'LightChartSettings',
       timeFrame: TimeframesHelper.getTimeframeByValue(TimeframeValue.Day)?.value,
@@ -195,6 +199,7 @@ export class WidgetFactoryService {
       ordersColumns: allOrdersColumns.filter(c => c.isDefault).map(c => c.columnId),
       stopOrdersColumns: allStopOrdersColumns.filter(c => c.isDefault).map(c => c.columnId),
       linkToActive: true,
+      badgeColor: 'yellow',
       title: `Блоттер`,
       isSoldPositionsHidden: true
     } as BlotterSettings;
@@ -208,8 +213,9 @@ export class WidgetFactoryService {
     }
 
     return {
-      ...this.selectedInstrument,
+      ...this.badges.yellow,
       linkToActive: true,
+      badgeColor: 'yellow',
       guid: newWidget.gridItem.label,
       settingsType: 'InfoSettings',
       title: `Инфо`,
@@ -222,8 +228,9 @@ export class WidgetFactoryService {
     }
 
     return {
-      ...this.selectedInstrument,
+      ...this.badges.yellow,
       linkToActive: true,
+      badgeColor: 'yellow',
       guid: newWidget.gridItem.label,
       settingsType: 'AllTradesSettings',
       title: `Все сделки`
@@ -260,11 +267,12 @@ export class WidgetFactoryService {
     }
 
     return {
-      ...this.selectedInstrument,
+      ...this.badges.yellow,
       guid: newWidget.gridItem.label,
       settingsType: 'TechChartSettings',
       title: 'Тех. анализ',
       linkToActive: true,
+      badgeColor: 'yellow',
       chartSettings: {}
     } as TechChartSettings;
   }
@@ -276,6 +284,7 @@ export class WidgetFactoryService {
 
     return {
       guid: newWidget.gridItem.label,
+      badgeColor: 'yellow',
       settingsType: 'AllInstrumentsSettings',
       title: 'Все инструменты',
       allInstrumentsColumns: allInstrumentsCols.filter(c => c.isDefault).map(col => col.columnId)

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -130,6 +130,7 @@ import { NzInputModule } from "ng-zorro-antd/input";
     NzDatePickerModule,
     NzTypographyModule,
     NzRadioModule,
+    NzPopoverModule,
     // modules
     CommonModule,
     FormsModule,

--- a/src/app/shared/utils/instruments.ts
+++ b/src/app/shared/utils/instruments.ts
@@ -13,6 +13,11 @@ export const instrumentsBadges = [
 ];
 
 /**
+ * default badge color
+ */
+export const defaultBadgeColor = 'yellow';
+
+/**
  * Determines the category of instrument by CFI code
  * @param cfi cfi code
  * @returns InstrumentType

--- a/src/app/shared/utils/instruments.ts
+++ b/src/app/shared/utils/instruments.ts
@@ -2,6 +2,17 @@ import { InstrumentType } from "../models/enums/instrument-type.model";
 import { InstrumentKey } from "../models/instruments/instrument-key.model";
 
 /**
+ * badge colors array
+ */
+export const instrumentsBadges = [
+  'yellow',
+  'blue',
+  'pink',
+  'red',
+  'orange'
+];
+
+/**
  * Determines the category of instrument by CFI code
  * @param cfi cfi code
  * @returns InstrumentType

--- a/src/app/shared/utils/settings-helper.ts
+++ b/src/app/shared/utils/settings-helper.ts
@@ -422,6 +422,7 @@ export function isEqualBlotterSettings(
       settings1.exchange == settings2.exchange &&
       settings1.portfolio == settings2.portfolio &&
       settings1.guid == settings2.guid &&
+      settings1.badgeColor == settings2.badgeColor &&
       isArrayEqual(settings1.ordersColumns, settings2.ordersColumns, (a, b) => a === b) &&
       isArrayEqual(settings1.stopOrdersColumns, settings2.stopOrdersColumns, (a, b) => a === b) &&
       isArrayEqual(settings1.positionsColumns, settings2.positionsColumns, (a, b) => a === b) &&

--- a/src/app/shared/utils/settings-helper.ts
+++ b/src/app/shared/utils/settings-helper.ts
@@ -339,7 +339,8 @@ export function isEqualOrderbookSettings(
       settings1.depth == settings2.depth &&
       settings1.showChart == settings2.showChart &&
       settings1.showTable == settings2.showTable &&
-      settings1.showYieldForBonds == settings2.showYieldForBonds
+      settings1.showYieldForBonds == settings2.showYieldForBonds &&
+      settings1.badgeColor == settings2.badgeColor
     );
   } else return false;
 }
@@ -366,6 +367,7 @@ export function isEqualScalperOrderBookSettings(
       settings1.showZeroVolumeItems == settings2.showZeroVolumeItems &&
       settings1.showSpreadItems == settings2.showSpreadItems &&
       settings1.highlightHighVolume == settings2.highlightHighVolume &&
+      settings1.badgeColor == settings2.badgeColor &&
       isArrayEqual(
         settings1.volumeHighlightOptions,
         settings2.volumeHighlightOptions,
@@ -401,7 +403,8 @@ export function isEqualLightChartSettings(
       settings1.timeFrame == settings2.timeFrame &&
       settings1.guid == settings2.guid &&
       settings1.width == settings2.width &&
-      settings1.height == settings2.height
+      settings1.height == settings2.height &&
+      settings1.badgeColor == settings2.badgeColor
     );
   } else return false;
 }
@@ -446,7 +449,8 @@ export function isEqualInstrumentSelectSettings(
       settings1.linkToActive == settings2.linkToActive &&
       settings1.guid == settings2.guid &&
       settings1.activeListId == settings2.activeListId &&
-      settings1.instrumentColumns == settings2.instrumentColumns
+      settings1.instrumentColumns == settings2.instrumentColumns &&
+      settings1.badgeColor == settings2.badgeColor
     );
   } else return false;
 }
@@ -466,7 +470,8 @@ export function isEqualInfoSettings(
       settings1.linkToActive == settings2.linkToActive &&
       settings1.guid == settings2.guid &&
       settings1.symbol == settings2.symbol &&
-      settings1.exchange == settings2.exchange
+      settings1.exchange == settings2.exchange &&
+      settings1.badgeColor == settings2.badgeColor
     );
   } else return false;
 }
@@ -487,7 +492,8 @@ export function isEqualTechChartSettings(
       settings1.guid == settings2.guid &&
       settings1.symbol == settings2.symbol &&
       settings1.exchange == settings2.exchange &&
-      settings1.chartSettings == settings2.chartSettings
+      settings1.chartSettings == settings2.chartSettings &&
+      settings1.badgeColor == settings2.badgeColor
     );
   } else return false;
 }

--- a/src/app/shared/utils/testing.ts
+++ b/src/app/shared/utils/testing.ts
@@ -137,7 +137,7 @@ export const ngZorroMockComponents = [
   }),
   mockDirective({
     selector: '[nz-icon]',
-    inputs: ['title', 'text', 'nzTwotoneColor', 'nzTheme']
+    inputs: ['title', 'text', 'nzTwotoneColor', 'nzTheme', 'nzType']
   }),
 ];
 

--- a/src/app/shared/utils/testing.ts
+++ b/src/app/shared/utils/testing.ts
@@ -124,6 +124,10 @@ export const ngZorroMockComponents = [
     selector: 'nz-modal',
     inputs: ['nzCancelText', 'nzVisible']
   }),
+  mockComponent({
+    selector: 'nz-badge',
+    inputs: ['nzColor', 'nzText', 'nzDropdownMenu']
+  }),
   mockDirective({selector: '[text]', inputs: ['text']}),
   mockDirective({selector: '[nzLayout]', inputs: ['nzLayout']}),
   mockDirective({selector: '[nzPopoverContent]', inputs: ['nzPopoverContent']}),

--- a/src/app/store/instruments/instruments-store.spec.ts
+++ b/src/app/store/instruments/instruments-store.spec.ts
@@ -1,16 +1,17 @@
 import { TestBed } from "@angular/core/testing";
 import { Store } from "@ngrx/store";
 import { sharedModuleImportForTests } from "../../shared/utils/testing";
-import { getSelectedInstrument } from "./instruments.selectors";
 import {
   of,
   take
 } from "rxjs";
 import { defaultInstrument } from "./instruments.reducer";
-import { selectNewInstrument } from "./instruments.actions";
 import { InstrumentKey } from "../../shared/models/instruments/instrument-key.model";
 import { InstrumentsService } from "../../modules/instruments/services/instruments.service";
-import { Instrument } from "../../shared/models/instruments/instrument.model";
+import { Instrument, InstrumentBadges } from "../../shared/models/instruments/instrument.model";
+import { getSelectedInstrumentByBadge, getSelectedInstrumentsWithBadges } from "./instruments.selectors";
+import { instrumentsBadges } from "../../shared/utils/instruments";
+import { selectNewInstrumentByBadge } from "./instruments.actions";
 
 describe('Instruments Store', () => {
   let store: Store;
@@ -50,23 +51,27 @@ describe('Instruments Store', () => {
     store = TestBed.inject(Store);
   });
 
-  it('default instrument should be selected', (done) => {
-    store.select(getSelectedInstrument).pipe(
+  it('default instruments with badges should be selected', (done) => {
+    store.select(getSelectedInstrumentsWithBadges).pipe(
       take(1)
     ).subscribe(instrument => {
+      const expectedState = instrumentsBadges.reduce((acc, curr) => {
+        acc[curr] = defaultInstrument;
+        return acc;
+      }, {} as InstrumentBadges);
       done();
-      expect(instrument).toEqual(defaultInstrument);
+      expect(instrument).toEqual(expectedState);
     });
   });
 
-  it('selectNewInstrument should request instrument details', (done) => {
+  it('selectNewInstrumentByBadge should request instrument details', (done) => {
       instrumentsServiceSpy.getInstrument.and.returnValue(of(expectedInstrumentDetails));
 
-      store.dispatch(selectNewInstrument({ instrument: expectedInstrumentKey }));
+      store.dispatch(selectNewInstrumentByBadge({ badgeColor: 'yellow', instrument: expectedInstrumentKey }));
 
       expect(instrumentsServiceSpy.getInstrument).toHaveBeenCalledOnceWith(expectedInstrumentKey);
 
-      store.select(getSelectedInstrument).pipe(
+      store.select(getSelectedInstrumentByBadge('yellow')).pipe(
         take(1)
       ).subscribe(instrument => {
         done();

--- a/src/app/store/instruments/instruments.actions.ts
+++ b/src/app/store/instruments/instruments.actions.ts
@@ -2,5 +2,5 @@ import { createAction, props } from '@ngrx/store';
 import { InstrumentKey } from 'src/app/shared/models/instruments/instrument-key.model';
 import { Instrument } from '../../shared/models/instruments/instrument.model';
 
-export const selectNewInstrumentByBadge = createAction('[Instruments] selectNewInstrumentByBadge', props<{ instrument: InstrumentKey, badgeColor: string }>());
+export const selectNewInstrumentByBadge = createAction('[Instruments] selectNewInstrumentByBadge', props<{ instrument: InstrumentKey, badgeColor?: string }>());
 export const newInstrumentByBadgeSelected = createAction('[Instruments] newInstrumentByBadgeSelected', props<{ instrument: Instrument, badgeColor: string }>());

--- a/src/app/store/instruments/instruments.actions.ts
+++ b/src/app/store/instruments/instruments.actions.ts
@@ -2,5 +2,5 @@ import { createAction, props } from '@ngrx/store';
 import { InstrumentKey } from 'src/app/shared/models/instruments/instrument-key.model';
 import { Instrument } from '../../shared/models/instruments/instrument.model';
 
-export const selectNewInstrument = createAction('[Instruments] SelectNewInstrument', props<{ instrument: InstrumentKey }>());
-export const newInstrumentSelected = createAction('[Instruments] NewInstrumentSelected', props<{ instrument: Instrument }>());
+export const selectNewInstrumentByBadge = createAction('[Instruments] selectNewInstrumentByBadge', props<{ instrument: InstrumentKey, badgeColor: string }>());
+export const newInstrumentByBadgeSelected = createAction('[Instruments] newInstrumentByBadgeSelected', props<{ instrument: Instrument, badgeColor: string }>());

--- a/src/app/store/instruments/instruments.effects.ts
+++ b/src/app/store/instruments/instruments.effects.ts
@@ -9,6 +9,7 @@ import {
 } from './instruments.actions';
 import { ErrorHandlerService } from 'src/app/shared/services/handle-error/error-handler.service';
 import { catchHttpError, mapWith } from 'src/app/shared/utils/observable-helper';
+import { defaultBadgeColor } from "../../shared/utils/instruments";
 
 @Injectable()
 export class InstrumentsEffects {
@@ -18,7 +19,7 @@ export class InstrumentsEffects {
       mapWith(
         action => this.instrumentsService.getInstrument(action.instrument)
           .pipe(catchHttpError<Instrument | null>(null, this.errorHandlerService)),
-        (action, instrument) => ({badgeColor: action.badgeColor, instrument})
+        (action, instrument) => ({badgeColor: action.badgeColor || defaultBadgeColor, instrument})
       ),
       filter(({instrument}) => !!instrument),
       map(({instrument, badgeColor}) => newInstrumentByBadgeSelected({instrument: instrument!, badgeColor}))

--- a/src/app/store/instruments/instruments.effects.ts
+++ b/src/app/store/instruments/instruments.effects.ts
@@ -1,21 +1,27 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { InstrumentsService } from 'src/app/modules/instruments/services/instruments.service';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { Instrument } from 'src/app/shared/models/instruments/instrument.model';
-import { newInstrumentSelected, selectNewInstrument, } from './instruments.actions';
+import {
+  newInstrumentByBadgeSelected,
+  selectNewInstrumentByBadge,
+} from './instruments.actions';
 import { ErrorHandlerService } from 'src/app/shared/services/handle-error/error-handler.service';
-import { catchHttpError } from 'src/app/shared/utils/observable-helper';
+import { catchHttpError, mapWith } from 'src/app/shared/utils/observable-helper';
 
 @Injectable()
 export class InstrumentsEffects {
-  loadInstruments$ = createEffect(() =>
+  selectInstrumentByBadge$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(selectNewInstrument),
-      switchMap(action => this.instrumentsService.getInstrument(action.instrument)),
-      catchHttpError<Instrument | null>(null, this.errorHandlerService),
-      filter((instrument): instrument is Instrument => !!instrument),
-      map((instrument) => newInstrumentSelected({ instrument }))
+      ofType(selectNewInstrumentByBadge),
+      mapWith(
+        action => this.instrumentsService.getInstrument(action.instrument)
+          .pipe(catchHttpError<Instrument | null>(null, this.errorHandlerService)),
+        (action, instrument) => ({badgeColor: action.badgeColor, instrument})
+      ),
+      filter(({instrument}) => !!instrument),
+      map(({instrument, badgeColor}) => newInstrumentByBadgeSelected({instrument: instrument!, badgeColor}))
     )
   );
 

--- a/src/app/store/instruments/instruments.reducer.ts
+++ b/src/app/store/instruments/instruments.reducer.ts
@@ -1,11 +1,14 @@
 import { createReducer, on } from '@ngrx/store';
 import * as InstrumentsActions from './instruments.actions';
 import { Instrument } from '../../shared/models/instruments/instrument.model';
+import { instrumentsBadges } from "../../shared/utils/instruments";
 
 export const instrumentsFeatureKey = 'instruments';
 
 export interface InstrumentsState {
-  selectedInstrument: Instrument;
+  selectedInstrumentWithBadge: {
+    [badgeColor: string]: Instrument
+  }
 }
 
 export const defaultInstrument: Instrument = {
@@ -21,18 +24,22 @@ export const defaultInstrument: Instrument = {
 };
 
 export const initialState: InstrumentsState = {
-  selectedInstrument: {
-    ...defaultInstrument
-  }
+  selectedInstrumentWithBadge: instrumentsBadges.reduce((acc, curr) => {
+    acc[curr] = { ...defaultInstrument };
+    return acc;
+  }, {} as {[badge: string]: Instrument})
 };
 
 export const reducer = createReducer(
   initialState,
-  on(InstrumentsActions.newInstrumentSelected, (state, { instrument }) => ({
-      ...state,
-      selectedInstrument: {
+
+  on(InstrumentsActions.newInstrumentByBadgeSelected, (state, { instrument, badgeColor}) => ({
+    ...state,
+    selectedInstrumentWithBadge: {
+      ...state.selectedInstrumentWithBadge,
+      [badgeColor]: {
         ...instrument
       }
-    })
-  )
+    }
+  }))
 );

--- a/src/app/store/instruments/instruments.selectors.ts
+++ b/src/app/store/instruments/instruments.selectors.ts
@@ -5,7 +5,12 @@ export const selectInstrumentsState = createFeatureSelector<fromInstruments.Inst
   fromInstruments.instrumentsFeatureKey
 );
 
-export const getSelectedInstrument = createSelector(
+export const getSelectedInstrumentsWithBadges = createSelector(
   selectInstrumentsState,
-  (state) => state.selectedInstrument
+  (state) => state.selectedInstrumentWithBadge
+);
+
+export const getSelectedInstrumentByBadge = (badgeColor: string) => createSelector(
+  selectInstrumentsState,
+  (state) => state.selectedInstrumentWithBadge?.[badgeColor]
 );

--- a/src/app/store/terminal-settings/terminal-settings.effects.ts
+++ b/src/app/store/terminal-settings/terminal-settings.effects.ts
@@ -16,11 +16,8 @@ import {
 } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
 import { selectTerminalSettingsState } from './terminal-settings.selectors';
-import { filter, take } from 'rxjs';
+import { filter } from 'rxjs';
 import { LocalStorageService } from "../../shared/services/local-storage.service";
-import { getAllSettings } from "../widget-settings/widget-settings.selectors";
-import { mapWith } from "../../shared/utils/observable-helper";
-import { updateWidgetSettings } from "../widget-settings/widget-settings.actions";
 
 @Injectable()
 export class TerminalSettingsEffects {
@@ -48,24 +45,6 @@ export class TerminalSettingsEffects {
         map(([, settings]) => settings.settings),
         filter((settings): settings is TerminalSettings => !!settings),
         tap(settings => this.saveSettingsToLocalStorage(settings)),
-        mapWith(
-          () => this.store.select(getAllSettings)
-            .pipe(
-              take(1),
-              map(ws => ws.filter(s => !!s.badgeColor))
-            ),
-          (ts, ws) => ({ ts, ws })
-          ),
-        tap(({ts, ws}) => {
-          if (!ts.badgesBind) {
-            ws.forEach(
-              s => this.store.dispatch(updateWidgetSettings({
-                settingGuid: s.guid,
-                changes: {badgeColor: 'yellow'}
-              }))
-            );
-          }
-        })
       );
     },
     {

--- a/src/app/store/widget-settings/widget-settings-store.spec.ts
+++ b/src/app/store/widget-settings/widget-settings-store.spec.ts
@@ -26,10 +26,10 @@ import {
   updateWidgetSettings
 } from "./widget-settings.actions";
 import { InstrumentKey } from "../../shared/models/instruments/instrument-key.model";
-import { selectNewInstrument } from "../instruments/instruments.actions";
 import { InstrumentsService } from "../../modules/instruments/services/instruments.service";
 import { PortfolioKey } from "../../shared/models/portfolio-key.model";
 import { selectNewPortfolio } from "../portfolios/portfolios.actions";
+import { selectNewInstrumentByBadge } from "../instruments/instruments.actions";
 
 describe('Widget Settings Store', () => {
   let store: Store;
@@ -226,7 +226,8 @@ describe('Widget Settings Store', () => {
         isin: generateRandomString(12),
         instrumentGroup: generateRandomString(4),
         // should be initially set to false because otherwise this setting will be updated with initial state selected instrument (SBER)
-        linkToActive: false
+        linkToActive: false,
+        badgeColor: 'yellow'
       };
 
       const instrumentInDependentSettings: AnySettings = {
@@ -303,7 +304,7 @@ describe('Widget Settings Store', () => {
         });
       });
 
-      store.dispatch(selectNewInstrument({ instrument: newInstrumentKey }));
+      store.dispatch(selectNewInstrumentByBadge({ instrument: newInstrumentKey, badgeColor: 'yellow' }));
       tick();
 
       store.select(selectWidgetSettingsState).pipe(

--- a/src/app/store/widget-settings/widget-settings.actions.ts
+++ b/src/app/store/widget-settings/widget-settings.actions.ts
@@ -25,6 +25,11 @@ export const updateWidgetSettingsInstrumentWithBadge = createAction(
   props<{ settingGuids: string[], badges: { [badgeColor: string]: InstrumentKey } }>()
 );
 
+export const setDefaultBadges = createAction(
+  '[WidgetSettings] Set Widget Settings To Default Badges',
+  props<{ settingGuids: string[] }>()
+);
+
 export const updateWidgetSettingsPortfolio = createAction(
   '[WidgetSettings] Update Widget Settings Portfolio',
   props<{ settingGuids: string[], newPortfolioKey: PortfolioKey }>()

--- a/src/app/store/widget-settings/widget-settings.actions.ts
+++ b/src/app/store/widget-settings/widget-settings.actions.ts
@@ -20,9 +20,9 @@ export const addWidgetSettings = createAction(
   props<{ settings: AnySettings[] }>()
 );
 
-export const updateWidgetSettingsInstrument = createAction(
-  '[WidgetSettings] Update Widget Settings Instrument',
-  props<{ settingGuids: string[], newInstrumentKey: InstrumentKey }>()
+export const updateWidgetSettingsInstrumentWithBadge = createAction(
+  '[WidgetSettings] Update Widget Settings Instrument With Badge',
+  props<{ settingGuids: string[], badges: { [badgeColor: string]: InstrumentKey } }>()
 );
 
 export const updateWidgetSettingsPortfolio = createAction(

--- a/src/app/store/widget-settings/widget-settings.effects.ts
+++ b/src/app/store/widget-settings/widget-settings.effects.ts
@@ -36,7 +36,7 @@ export class WidgetSettingsEffects {
       ofType(
         WidgetSettingsActions.addWidgetSettings,
         WidgetSettingsActions.updateWidgetSettings,
-        WidgetSettingsActions.updateWidgetSettingsInstrument,
+        WidgetSettingsActions.updateWidgetSettingsInstrumentWithBadge,
         WidgetSettingsActions.updateWidgetSettingsPortfolio,
         WidgetSettingsActions.removeWidgetSettings,
         WidgetSettingsActions.removeAllWidgetSettings
@@ -49,7 +49,9 @@ export class WidgetSettingsEffects {
       return this.actions$.pipe(
         ofType(WidgetSettingsActions.saveSettings),
         withLatestFrom(this.store.select(getAllSettings)),
-        tap(([, settings]) => this.saveSettingsToLocalStorage(settings))
+        tap(([, settings]) => {
+          this.saveSettingsToLocalStorage(settings);
+        })
       );
     },
     { dispatch: false });

--- a/src/app/store/widget-settings/widget-settings.reducer.ts
+++ b/src/app/store/widget-settings/widget-settings.reducer.ts
@@ -49,20 +49,20 @@ export const reducer = createReducer(
   }),
 
   on(
-    WidgetSettingsActions.updateWidgetSettingsInstrument,
+    WidgetSettingsActions.updateWidgetSettingsInstrumentWithBadge,
     (state, {
       settingGuids,
-      newInstrumentKey
+      badges
     }) => {
       const updates: Update<AnySettings>[] = [];
       settingGuids.forEach(s => updates.push({
         id: s,
         changes: {
           ...state.entities[s],
-          symbol: newInstrumentKey.symbol,
-          exchange: newInstrumentKey.exchange,
-          instrumentGroup: newInstrumentKey.instrumentGroup,
-          isin: newInstrumentKey.isin
+          symbol: badges[state.entities[s]?.badgeColor!]?.symbol,
+          exchange: badges[state.entities[s]?.badgeColor!]?.exchange,
+          instrumentGroup: badges[state.entities[s]?.badgeColor!]?.instrumentGroup,
+          isin: badges[state.entities[s]?.badgeColor!]?.isin
         }
       }));
 

--- a/src/app/store/widget-settings/widget-settings.reducer.ts
+++ b/src/app/store/widget-settings/widget-settings.reducer.ts
@@ -11,6 +11,7 @@ import { AnySettings } from "../../shared/models/settings/any-settings.model";
 import { EntityStatus } from "../../shared/models/enums/entity-status";
 import * as WidgetSettingsActions from "./widget-settings.actions";
 import { Update } from "@ngrx/entity/src/models";
+import { defaultBadgeColor } from "../../shared/utils/instruments";
 
 export const widgetSettingsFeatureKey = 'widgetSettings';
 
@@ -63,6 +64,31 @@ export const reducer = createReducer(
           exchange: badges[state.entities[s]?.badgeColor!]?.exchange,
           instrumentGroup: badges[state.entities[s]?.badgeColor!]?.instrumentGroup,
           isin: badges[state.entities[s]?.badgeColor!]?.isin
+        }
+      }));
+
+      if (updates.length > 0) {
+        return adapter.updateMany(
+          updates,
+          state
+        );
+      }
+
+      return state;
+    }
+  ),
+
+  on(
+    WidgetSettingsActions.setDefaultBadges,
+    (state, {
+      settingGuids
+    }) => {
+      const updates: Update<AnySettings>[] = [];
+      settingGuids.forEach(s => updates.push({
+        id: s,
+        changes: {
+          ...state.entities[s],
+          badgeColor: defaultBadgeColor
         }
       }));
 


### PR DESCRIPTION
# Description

add multiple binding widgets to instruments select

# Testing

open user setting 
turn on badges binding
select badge color on instruments-select/blotter/all-instruments
select same badge color on widget you want to change
select instrument

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
