### PR TITLE
add profit info to scalper orderbook

### DIFF
--- a/src/app/modules/command/components/command-header/command-header.component.ts
+++ b/src/app/modules/command/components/command-header/command-header.component.ts
@@ -15,9 +15,6 @@ import { getDayChange, getDayChangePerPrice } from 'src/app/shared/utils/price';
 import { PriceData } from '../../models/price-data.model';
 import { buyColor, sellColor } from 'src/app/shared/models/settings/styles-constants';
 import { PositionsService } from 'src/app/shared/services/positions.service';
-import { PortfolioKey } from 'src/app/shared/models/portfolio-key.model';
-import { Store } from '@ngrx/store';
-import { getSelectedPortfolio } from '../../../../store/portfolios/portfolios.selectors';
 import { Position } from '../../../../shared/models/positions/position.model';
 import { startWith } from 'rxjs/operators';
 import { Instrument } from '../../../../shared/models/instruments/instrument.model';
@@ -41,8 +38,8 @@ export class CommandHeaderComponent implements OnInit, OnDestroy {
     private readonly quoteService: QuotesService,
     private readonly commandsService: CommandsService,
     private readonly history: HistoryService,
-    private readonly positionService: PositionsService,
-    private readonly store: Store) {
+    private readonly positionService: PositionsService
+  ) {
   }
 
   @Input()
@@ -61,12 +58,8 @@ export class CommandHeaderComponent implements OnInit, OnDestroy {
         shareReplay()
       );
 
-    const portfolio$ = this.store.select(getSelectedPortfolio).pipe(
-      filter((p): p is PortfolioKey => !!p)
-    );
-
-    const position$ = combineLatest([instrument$, portfolio$]).pipe(
-      switchMap(([instrument, portfolio]) => this.positionService.getByPortfolio(portfolio.portfolio, portfolio.exchange, instrument.symbol)),
+    const position$ = instrument$.pipe(
+      switchMap((instrument) => this.positionService.getByPortfolio(instrument.exchange, instrument.symbol)),
       filter((p): p is Position => !!p),
       map(p => ({
         abs: Math.abs(p.qtyTFutureBatch),

--- a/src/app/modules/orderbook/components/scalper-order-book/scalper-order-book.component.html
+++ b/src/app/modules/orderbook/components/scalper-order-book/scalper-order-book.component.html
@@ -43,5 +43,17 @@
       </tbody>
     </nz-table>
     <nz-empty *ngIf="orderBook.rows.length === 0" nzNotFoundImage="simple"></nz-empty>
+    <div *ngIf="positionInfo$ | async as positionInfo" class="position-profit">
+      <span>{{positionInfo.avgPrice}}</span>
+      <span [ngClass]="{'positive-profit': positionInfo.qtyTFuture > 0, 'negative-profit': positionInfo.qtyTFuture < 0}">
+        {{positionInfo.qtyTFuture > 0 ? positionInfo.qtyTFuture : -positionInfo.qtyTFuture}}л.
+      </span>
+      <span
+        *ngIf="getProfit(positionInfo.avgPrice, orderBook, positionInfo.qtyTFuture > 0) as profit"
+        [ngClass]="{'positive-profit': profit > 0, 'negative-profit': profit < 0}"
+      >
+        {{profit > 0 ? profit : -profit}}п.
+      </span>
+    </div>
   </div>
 </div>

--- a/src/app/modules/orderbook/components/scalper-order-book/scalper-order-book.component.less
+++ b/src/app/modules/orderbook/components/scalper-order-book/scalper-order-book.component.less
@@ -52,3 +52,23 @@
     margin-left: 0.5em;
   }
 }
+
+.position-profit {
+  font-weight: bold;
+  font-size: 1.2em;
+  margin-top: 10px;
+  display: flex;
+  justify-content: center;
+
+  span:not(:last-child) {
+    margin-right: 10px;
+  }
+
+  .negative-profit {
+    color: @sell-color;
+  }
+
+  .positive-profit {
+    color: @buy-color;
+  }
+}

--- a/src/app/modules/orderbook/components/scalper-order-book/scalper-order-book.component.spec.ts
+++ b/src/app/modules/orderbook/components/scalper-order-book/scalper-order-book.component.spec.ts
@@ -8,6 +8,7 @@ import {
 import { ScalperOrderBookComponent } from './scalper-order-book.component';
 import {
   BehaviorSubject,
+  of,
   Subject,
   take
 } from "rxjs";
@@ -34,6 +35,7 @@ import { HotKeyCommandService } from "../../../../shared/services/hot-key-comman
 import { TerminalCommand } from "../../../../shared/models/terminal-command";
 import { ScalperOrderBookCommands } from "../../models/scalper-order-book-commands";
 import { Side } from "../../../../shared/models/enums/side.model";
+import { PositionsService } from "../../../../shared/services/positions.service";
 
 describe('ScalperOrderBookComponent', () => {
   let component: ScalperOrderBookComponent;
@@ -126,6 +128,7 @@ describe('ScalperOrderBookComponent', () => {
         { provide: InstrumentsService, useValue: instrumentsServiceSpy },
         { provide: HotKeyCommandService, useValue: hotKeyCommandServiceSpy },
         { provide: ScalperOrdersService, useValue: scalperOrdersServiceSpy },
+        { provide: PositionsService, useValue: { getByPortfolio: jasmine.createSpy('getByPortfolio').and.returnValue(of(null)) } }
       ],
     })
     .compileComponents();

--- a/src/app/shared/services/positions.service.spec.ts
+++ b/src/app/shared/services/positions.service.spec.ts
@@ -6,6 +6,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { PositionsService } from './positions.service';
 import { ErrorHandlerService } from "./handle-error/error-handler.service";
+import { sharedModuleImportForTests } from "../utils/testing";
 
 describe('PositionsService', () => {
   let service: PositionsService;
@@ -16,7 +17,8 @@ describe('PositionsService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        HttpClientTestingModule
+        HttpClientTestingModule,
+        ...sharedModuleImportForTests
       ],
       providers: [
         PositionsService,


### PR DESCRIPTION
Fixes #364 

# Description

add profit info to scalper orderbook

# Testing

add scalper orderbook widget
select instrument with active positions
look at the bottom of scalper orderbook

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
