### PR TITLE
Issue #306: Move list selection from settings to widget

### DIFF
--- a/src/app/modules/instruments/components/instrument-select-settings/instrument-select-settings.component.html
+++ b/src/app/modules/instruments/components/instrument-select-settings/instrument-select-settings.component.html
@@ -3,14 +3,6 @@
     <nz-tab nzTitle="Настройки">
       <div>
         <form (ngSubmit)="saveSettings()" [formGroup]="settingsForm" [nzLayout]="'horizontal'" nz-form>
-          <nz-form-item>
-            <nz-form-control *ngIf="collection$ | async as collection" nzErrorTip="Выберите отображаемый список">
-              <nz-form-label nzFor="activeListId" nzRequired>Список инструментов</nz-form-label>
-              <nz-select formControlName='activeListId'>
-                <nz-option *ngFor="let list of collection.collection" [nzValue]="list.id" [nzLabel]="list.title"></nz-option>
-              </nz-select>
-            </nz-form-control>
-          </nz-form-item>
           <nz-form-item class="compact">
             <nz-form-control nzErrorTip="Выберите колонки">
               <nz-form-label nzRequired nzFor="instrumentColumns">Колонки инструментов</nz-form-label>

--- a/src/app/modules/instruments/components/instrument-select-settings/instrument-select-settings.component.spec.ts
+++ b/src/app/modules/instruments/components/instrument-select-settings/instrument-select-settings.component.spec.ts
@@ -4,14 +4,13 @@ import {
 } from '@angular/core/testing';
 
 import { InstrumentSelectSettingsComponent } from './instrument-select-settings.component';
-import { WatchlistCollectionService } from '../../services/watchlist-collection.service';
-import {
-  BehaviorSubject,
-  Subject
-} from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { InstrumentSelectSettings } from '../../../../shared/models/settings/instrument-select-settings.model';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
-import { mockComponent, ngZorroMockComponents } from "../../../../shared/utils/testing";
+import {
+  mockComponent,
+  ngZorroMockComponents
+} from "../../../../shared/utils/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { NzSelectModule } from "ng-zorro-antd/select";
 import { ReactiveFormsModule } from "@angular/forms";
@@ -19,11 +18,6 @@ import { ReactiveFormsModule } from "@angular/forms";
 describe('InstrumentSelectSettingsComponent', () => {
   let component: InstrumentSelectSettingsComponent;
   let fixture: ComponentFixture<InstrumentSelectSettingsComponent>;
-
-  const watchlistCollectionServiceSpy = jasmine.createSpyObj('WatchlistCollectionService', ['collectionChanged$', 'getWatchlistCollection']);
-
-  const collectionChangedMock = new Subject();
-  watchlistCollectionServiceSpy.collectionChanged$ = collectionChangedMock.asObservable();
 
   const getSettingsMock = new BehaviorSubject({} as InstrumentSelectSettings);
 
@@ -49,8 +43,7 @@ describe('InstrumentSelectSettingsComponent', () => {
             getSettings: jasmine.createSpy('getSettings').and.returnValue(getSettingsMock),
             updateSettings: jasmine.createSpy('updateSettings').and.callThrough()
           }
-        },
-        { provide: WatchlistCollectionService, useValue: watchlistCollectionServiceSpy },
+        }
       ]
     }).compileComponents();
   });

--- a/src/app/modules/instruments/components/instrument-select-settings/instrument-select-settings.component.ts
+++ b/src/app/modules/instruments/components/instrument-select-settings/instrument-select-settings.component.ts
@@ -13,20 +13,12 @@ import {
 } from 'src/app/shared/models/settings/instrument-select-settings.model';
 import {
   FormControl,
-  FormGroup,
-  Validators
+  FormGroup
 } from '@angular/forms';
-import { WatchlistCollectionService } from '../../services/watchlist-collection.service';
 import {
-  Observable,
   Subject,
   takeUntil
 } from 'rxjs';
-import {
-  map,
-  startWith
-} from 'rxjs/operators';
-import { WatchlistCollection } from '../../models/watchlist.model';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
 
 @Component({
@@ -37,24 +29,16 @@ import { WidgetSettingsService } from "../../../../shared/services/widget-settin
 export class InstrumentSelectSettingsComponent implements OnInit, OnDestroy {
   settingsForm!: FormGroup;
   allInstrumentColumns: ColumnIds[] = allInstrumentsColumns;
-  collection$?: Observable<WatchlistCollection>;
   @Input()
   guid!: string;
   @Output()
   settingsChange: EventEmitter<InstrumentSelectSettings> = new EventEmitter<InstrumentSelectSettings>();
   private destroy$: Subject<boolean> = new Subject<boolean>();
 
-  constructor(
-    private readonly settingsService: WidgetSettingsService,
-    private readonly watchlistCollectionService: WatchlistCollectionService) {
+  constructor(private readonly settingsService: WidgetSettingsService) {
   }
 
   ngOnInit(): void {
-    this.collection$ = this.watchlistCollectionService.collectionChanged$.pipe(
-      startWith(null),
-      map(() => this.watchlistCollectionService.getWatchlistCollection()),
-    );
-
     this.settingsService.getSettings<InstrumentSelectSettings>(this.guid).pipe(
       takeUntil(this.destroy$)
     ).subscribe(settings => {
@@ -82,7 +66,6 @@ export class InstrumentSelectSettingsComponent implements OnInit, OnDestroy {
 
   private buildSettingsForm(currentSettings: InstrumentSelectSettings) {
     this.settingsForm = new FormGroup({
-      activeListId: new FormControl(currentSettings.activeListId, [Validators.required]),
       instrumentColumns: new FormControl(currentSettings.instrumentColumns)
     });
   }

--- a/src/app/modules/instruments/components/instrument-select/instrument-select.component.html
+++ b/src/app/modules/instruments/components/instrument-select/instrument-select.component.html
@@ -1,24 +1,41 @@
-<div (mousedown)='$event.stopPropagation()'>
-  <input class='whole ant-input'
-    placeholder='Поиск...'
-    nz-input
-    #inputEl
-    (mousedown)="$event.stopPropagation()"
-    [(ngModel)]="inputValue"
-    (ngModelChange)="onChange($event)"
-    [nzAutocomplete]="auto"
-  />
-  <nz-autocomplete #auto>
-    <nz-auto-option
-     *ngFor="let option of filteredInstruments$ | async" [nzLabel]="option.symbol" [nzValue]="option.description"
-     (selectionChange)='onSelect($event, option)'>
+<ng-container *ngIf="settings$ | async as settings">
+  <div class="header">
+    <div (mousedown)='$event.stopPropagation()' class="search-field">
+      <input #inputEl
+             (mousedown)="$event.stopPropagation()"
+             (ngModelChange)="onChange($event)"
+             [(ngModel)]="inputValue"
+             [nzAutocomplete]="auto"
+             class='whole ant-input'
+             nz-input
+             placeholder='Поиск...'
+      />
+      <nz-autocomplete #auto>
+        <nz-auto-option
+          (selectionChange)='onSelect($event, option)' *ngFor="let option of filteredInstruments$ | async"
+          [nzLabel]="option.symbol"
+          [nzValue]="option.description">
       <span class='search-row'>
         <nz-tag>{{ option.symbol }}</nz-tag>
         <span class='row-center'>{{ option.shortName }}</span>
         <nz-tag *ngIf='option.instrumentGroup'>{{ option.instrumentGroup }}</nz-tag>
         <nz-tag>{{ option.exchange }}</nz-tag>
       </span>
-    </nz-auto-option>
-  </nz-autocomplete>
+        </nz-auto-option>
+      </nz-autocomplete>
+    </div>
+    <div *ngIf="(collection$ | async)!.collection as collection" class="watch-list-collection-select">
+      <button *ngIf="collection.length > 0" [nzDropdownMenu]="menu" nz-button nz-dropdown>
+        <span nz-icon nzTheme="outline" nzType="menu"></span>
+      </button>
+      <nz-dropdown-menu #menu="nzDropdownMenu">
+        <ul nz-menu nzSelectable>
+          <li (click)="selectCollection(list.id)" *ngFor="let list of collection" nz-menu-item [nzSelected]="settings.activeListId === list.id">
+            <span>{{list.title}}</span>
+          </li>
+        </ul>
+      </nz-dropdown-menu>
+    </div>
+  </div>
   <ats-watchlist-table [guid]="guid"></ats-watchlist-table>
-</div>
+</ng-container>

--- a/src/app/modules/instruments/components/instrument-select/instrument-select.component.less
+++ b/src/app/modules/instruments/components/instrument-select/instrument-select.component.less
@@ -1,11 +1,26 @@
-.whole {
-  width: 100%;
-}
-
-.search-row {
+.header {
   display: flex;
+  flex-direction: row;
+  padding-bottom: 5px;
+
+  .search-field {
+    flex: 1;
+    .whole {
+      width: 100%;
+    }
+
+    .search-row {
+      display: flex;
+    }
+
+    .row-center {
+      flex-grow: 1;
+    }
+  }
+
+  .watch-list-collection-select {
+    padding-left: 5px;
+  }
 }
 
-.row-center {
-  flex-grow: 1;
-}
+

--- a/src/app/modules/instruments/components/instrument-select/instrument-select.component.spec.ts
+++ b/src/app/modules/instruments/components/instrument-select/instrument-select.component.spec.ts
@@ -4,7 +4,10 @@ import {
 } from '@angular/core/testing';
 import { InstrumentsService } from '../../services/instruments.service';
 import { InstrumentSelectComponent } from './instrument-select.component';
-import { mockComponent, sharedModuleImportForTests } from '../../../../shared/utils/testing';
+import {
+  mockComponent,
+  sharedModuleImportForTests
+} from '../../../../shared/utils/testing';
 import { WatchlistCollectionService } from '../../services/watchlist-collection.service';
 import {
   BehaviorSubject,
@@ -12,12 +15,15 @@ import {
 } from 'rxjs';
 import { InstrumentSelectSettings } from '../../../../shared/models/settings/instrument-select-settings.model';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
+import { WatchlistCollection } from '../../models/watchlist.model';
 
 describe('InstrumentSelectComponent', () => {
   let component: InstrumentSelectComponent;
   let fixture: ComponentFixture<InstrumentSelectComponent>;
   const spyInstrs = jasmine.createSpyObj('InstrumentsService', ['getInstruments']);
-  const watchlistCollectionServiceSpy = jasmine.createSpyObj('WatchlistCollectionService', ['addItemsToList']);
+  const watchlistCollectionServiceSpy = jasmine.createSpyObj('WatchlistCollectionService', ['addItemsToList', 'collectionChanged$', 'getWatchlistCollection']);
+  watchlistCollectionServiceSpy.collectionChanged$ = of({});
+  watchlistCollectionServiceSpy.getWatchlistCollection.and.returnValue({ collection: [] } as WatchlistCollection);
 
   const getSettingsMock = new BehaviorSubject({} as InstrumentSelectSettings);
 


### PR DESCRIPTION
Fixes #306 

# Description

 Move list selection from settings to widget

# Testing

Add instruments widget. Go to settings and add several lists. Try to change list in widget (button next to search field)

# Risk

No major changes

# Do you agree with those?
- [x] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [x] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
