### PR TITLE
Feedbacks

### DIFF
--- a/src/app/modules/dashboard/components/navbar/navbar.component.html
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.html
@@ -1,7 +1,7 @@
 <nz-header>
   <ul nz-menu nzTheme="dark" nzMode="horizontal">
-    <li nz-menu-item class="logo-menu-item">
-      <a [routerLink]="['/']" nzSuccess><div class="logo"></div></a>
+    <li nz-menu-item class="logo logo-menu-item">
+      <a [routerLink]="['/']"></a>
     </li>
     <li nz-menu-item
       class='menu-item icon-li'
@@ -47,10 +47,17 @@
         [title]="joyrideContent.step4.title"
         [text]="joyrideContent.step4.text"></i>
     </li>
-    <button class="right" nz-button nz-dropdown [nzDropdownMenu]="rightMenu" nzPlacement="bottomRight">
-      <i nz-icon nzType="user"></i>
-    </button>
   </ul>
+  <div class="right">
+      <div class="notifications">
+        <ats-notification-button ></ats-notification-button>
+      </div>
+    <div>
+      <button nz-button nz-dropdown [nzDropdownMenu]="rightMenu" nzPlacement="bottomRight">
+        <i nz-icon nzType="user"></i>
+      </button>
+    </div>
+  </div>
 </nz-header>
 
 

--- a/src/app/modules/dashboard/components/navbar/navbar.component.html
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.html
@@ -50,7 +50,7 @@
   </ul>
   <div class="right">
       <div class="notifications">
-        <ats-notification-button ></ats-notification-button>
+        <ats-notification-button></ats-notification-button>
       </div>
     <div>
       <button nz-button nz-dropdown [nzDropdownMenu]="rightMenu" nzPlacement="bottomRight">

--- a/src/app/modules/dashboard/components/navbar/navbar.component.less
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.less
@@ -4,11 +4,25 @@
 @indent: 2px;
 
 nz-header {
+  display: flex;
+  flex-direction: row;
+
+  height: initial;
   line-height: @navbar-height;
-  height: @navbar-height;
+  min-height: @navbar-height;
   padding-left: 5px;
   padding-right: 5px;
 
+  .right {
+    margin-left: auto;
+    display: flex;
+    gap: 0 10px;
+
+    @media (max-width: 420px) {
+      flex-direction: column;
+      gap: 5px 0;
+    }
+  }
 }
 
 ::ng-deep{
@@ -22,11 +36,6 @@ nz-header {
   height: @navbar-height;
   width: @navbar-height - @indent;
   background-repeat: no-repeat;
-  float: left;
-}
-
-.right {
-  float: right;
 }
 
 .managing-icon {

--- a/src/app/modules/dashboard/components/navbar/navbar.component.spec.ts
+++ b/src/app/modules/dashboard/components/navbar/navbar.component.spec.ts
@@ -30,6 +30,7 @@ describe('NavbarComponent', () => {
         NavbarComponent,
         ...ngZorroMockComponents,
         mockComponent({selector: 'ats-widget-menu'}),
+        mockComponent({selector: 'ats-notification-button'}),
       ],
       providers: [
         { provide: AccountService, useValue: spyAccount },

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -23,6 +23,7 @@ import { TechChartModule } from "../tech-chart/tech-chart.module";
 import { AllInstrumentsModule } from "../all-instruments/all-instruments.module";
 import { OrderSubmitModule } from "../order-submit/order-submit.module";
 import { NotificationsModule } from '../notifications/notifications.module';
+import { FeedbackModule } from '../feedback/feedback.module';
 
 @NgModule({
   declarations: [
@@ -50,7 +51,8 @@ import { NotificationsModule } from '../notifications/notifications.module';
     TechChartModule,
     AllInstrumentsModule,
     OrderSubmitModule,
-    NotificationsModule
+    NotificationsModule,
+    FeedbackModule,
     // components
   ],
   providers: [

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -22,6 +22,7 @@ import { ExchangeRateModule } from "../exchange-rate/exchange-rate.module";
 import { TechChartModule } from "../tech-chart/tech-chart.module";
 import { AllInstrumentsModule } from "../all-instruments/all-instruments.module";
 import { OrderSubmitModule } from "../order-submit/order-submit.module";
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @NgModule({
   declarations: [
@@ -48,7 +49,8 @@ import { OrderSubmitModule } from "../order-submit/order-submit.module";
     ExchangeRateModule,
     TechChartModule,
     AllInstrumentsModule,
-    OrderSubmitModule
+    OrderSubmitModule,
+    NotificationsModule
     // components
   ],
   providers: [

--- a/src/app/modules/dashboard/widgets/dashboard-widget/dashboard-widget.component.html
+++ b/src/app/modules/dashboard/widgets/dashboard-widget/dashboard-widget.component.html
@@ -5,6 +5,7 @@
   <ats-help-widget></ats-help-widget>
   <ats-terminal-settings-widget></ats-terminal-settings-widget>
   <ats-news-modal-widget></ats-news-modal-widget>
+  <ats-feedback-widget></ats-feedback-widget>
   <nz-content>
     <ats-dashboard></ats-dashboard>
   </nz-content>

--- a/src/app/modules/dashboard/widgets/dashboard-widget/dashboard-widget.component.spec.ts
+++ b/src/app/modules/dashboard/widgets/dashboard-widget/dashboard-widget.component.spec.ts
@@ -27,7 +27,8 @@ describe('DashboardWidgetComponent', () => {
         mockComponent({selector: 'ats-edit-widget'}),
         mockComponent({selector: 'ats-help-widget'}),
         mockComponent({selector: 'ats-terminal-settings-widget'}),
-        mockComponent({selector: 'ats-news-modal-widget'})
+        mockComponent({selector: 'ats-news-modal-widget'}),
+        mockComponent({selector: 'ats-feedback-widget'})
       ],
       providers: [
         { provide: AuthService, useValue: spyAuth },

--- a/src/app/modules/feedback/feedback.module.ts
+++ b/src/app/modules/feedback/feedback.module.ts
@@ -1,0 +1,36 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NzModalModule } from 'ng-zorro-antd/modal';
+import { FeedbackWidgetComponent } from './widgets/feedback-widget/feedback-widget.component';
+import {
+  FormsModule,
+  ReactiveFormsModule
+} from '@angular/forms';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzRateModule } from 'ng-zorro-antd/rate';
+import { NzInputModule } from 'ng-zorro-antd/input';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
+
+
+@NgModule({
+  declarations: [
+    FeedbackWidgetComponent
+  ],
+  exports: [
+    FeedbackWidgetComponent
+  ],
+  imports: [
+    CommonModule,
+    NzModalModule,
+    ReactiveFormsModule,
+    NzFormModule,
+    NzRateModule,
+    NzInputModule,
+    NzButtonModule,
+    FormsModule,
+    NzTypographyModule
+  ]
+})
+export class FeedbackModule {
+}

--- a/src/app/modules/feedback/models/feedback.model.ts
+++ b/src/app/modules/feedback/models/feedback.model.ts
@@ -20,4 +20,5 @@ export interface FeedbackMeta {
 
 export interface UnansweredFeedback extends NewFeedback {
   isRead: boolean;
+  date?: number;
 }

--- a/src/app/modules/feedback/models/feedback.model.ts
+++ b/src/app/modules/feedback/models/feedback.model.ts
@@ -1,5 +1,5 @@
 ﻿export interface NewFeedback {
-  feedbackCode: string;
+  code: string;
   description: string;
 }
 
@@ -11,4 +11,13 @@ export interface SendFeedBackRequest {
 
 export interface SendFeedBackResponse {
   error?: string;
+}
+
+export interface FeedbackMeta {
+  lastCheck?: number;
+  lastUnansweredFeedback?: UnansweredFeedback
+}
+
+export interface UnansweredFeedback extends NewFeedback {
+  isRead: boolean;
 }

--- a/src/app/modules/feedback/models/feedback.model.ts
+++ b/src/app/modules/feedback/models/feedback.model.ts
@@ -1,0 +1,14 @@
+﻿export interface NewFeedback {
+  feedbackCode: string;
+  description: string;
+}
+
+export interface SendFeedBackRequest {
+  rate: number;
+  comment: string;
+  feedbackCode: string;
+}
+
+export interface SendFeedBackResponse {
+  error?: string;
+}

--- a/src/app/modules/feedback/services/feedback-notifications-provider.spec.ts
+++ b/src/app/modules/feedback/services/feedback-notifications-provider.spec.ts
@@ -1,0 +1,200 @@
+﻿import {
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed
+} from '@angular/core/testing';
+
+import { FeedbackService } from './feedback.service';
+import { FeedbackNotificationsProvider } from './feedback-notifications-provider';
+import { ModalService } from '../../../shared/services/modal.service';
+import {
+  Observable,
+  of,
+  shareReplay,
+  take
+} from 'rxjs';
+import { NewFeedback } from '../models/feedback.model';
+import { NotificationMeta } from '../../notifications/models/notification.model';
+
+describe('FeedbackNotificationsProvider', () => {
+  let provider: FeedbackNotificationsProvider;
+
+  let feedbackServiceSpy: any;
+  let modalServiceSpy: any;
+
+  const readNotification = (notifications$: Observable<NotificationMeta[]>, read: (notifications: NotificationMeta[]) => void) => {
+    notifications$.pipe(
+      take(1)
+    ).subscribe(x => read(x));
+  };
+
+  beforeEach(() => {
+    feedbackServiceSpy = jasmine.createSpyObj(
+      'FeedbackService',
+      [
+        'getLastFeedbackCheck',
+        'setLastFeedbackCheck',
+        'requestFeedback'
+      ]);
+
+    modalServiceSpy = jasmine.createSpyObj('ModalService', ['openVoteModal']);
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        FeedbackNotificationsProvider,
+        {
+          provide: FeedbackService,
+          useValue: feedbackServiceSpy
+        },
+        {
+          provide: ModalService,
+          useValue: modalServiceSpy
+        }
+      ]
+    });
+
+    provider = TestBed.inject(FeedbackNotificationsProvider);
+  });
+
+  afterEach(function () {
+    jasmine.clock().uninstall();
+  });
+
+  it('should be created', () => {
+    expect(provider).toBeTruthy();
+  });
+
+  it('should request feedback after 1 hours at first start', fakeAsync(() => {
+      feedbackServiceSpy.getLastFeedbackCheck.and.returnValue(null);
+      feedbackServiceSpy.requestFeedback.and.returnValue(of(null));
+
+      provider.getNotifications().subscribe();
+      jasmine.clock().tick(5000);
+
+      expect(feedbackServiceSpy.requestFeedback).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(3600 * 1000 + 2 * 1000);
+
+      expect(feedbackServiceSpy.requestFeedback).toHaveBeenCalled();
+      discardPeriodicTasks();
+    })
+  );
+
+  it('should request feedback after 1 hours of last check', fakeAsync(() => {
+      feedbackServiceSpy.getLastFeedbackCheck.and.returnValue(new Date().getTime());
+      feedbackServiceSpy.requestFeedback.and.returnValue(of(null));
+
+      provider.getNotifications().subscribe();
+      jasmine.clock().tick(5000);
+
+      expect(feedbackServiceSpy.requestFeedback).not.toHaveBeenCalled();
+
+      jasmine.clock().tick(3600 * 1000 + 2 * 1000);
+
+      expect(feedbackServiceSpy.requestFeedback).toHaveBeenCalled();
+      discardPeriodicTasks();
+    })
+  );
+
+  it('should remove notification after read', fakeAsync(() => {
+      const testFeedbackRequest = {
+        feedbackCode: 'testCode',
+        description: 'description'
+      } as NewFeedback;
+
+      feedbackServiceSpy.getLastFeedbackCheck.and.returnValue(new Date().getTime() - (3600 * 1000 + 5 * 1000));
+      feedbackServiceSpy.requestFeedback.and.returnValue(of(testFeedbackRequest));
+
+      const notifications$ = provider.getNotifications().pipe(
+        shareReplay(1)
+      );
+
+      notifications$.subscribe();
+      jasmine.clock().tick(5000);
+
+      expect(feedbackServiceSpy.requestFeedback).toHaveBeenCalled();
+
+      readNotification(notifications$, notifications => {
+        expect(notifications.length).toBe(1);
+
+        notifications[0].markAsRead!();
+
+        readNotification(notifications$, notifications => {
+          expect(notifications.length).toBe(0);
+        });
+      });
+
+      discardPeriodicTasks();
+    })
+  );
+
+  it('should return new notification after read', fakeAsync(() => {
+      const testFeedbackRequest = {
+        feedbackCode: 'testCode',
+        description: 'description'
+      } as NewFeedback;
+
+      feedbackServiceSpy.getLastFeedbackCheck.and.returnValue(new Date().getTime() - (3600 * 1000 + 5 * 1000));
+      feedbackServiceSpy.requestFeedback.and.returnValue(of(testFeedbackRequest));
+
+      const notifications$ = provider.getNotifications().pipe(
+        shareReplay(1)
+      );
+
+      notifications$.subscribe();
+      jasmine.clock().tick(5000);
+
+      expect(feedbackServiceSpy.requestFeedback).toHaveBeenCalled();
+
+      readNotification(notifications$, notifications => {
+        expect(notifications.length).toBe(1);
+
+        notifications[0].markAsRead!();
+
+        readNotification(notifications$, notifications => {
+          expect(notifications.length).toBe(0);
+
+          jasmine.clock().tick(3600 * 1000 + 5 * 1000);
+
+          readNotification(notifications$, notifications => {
+            expect(notifications.length).toBe(1);
+          });
+        });
+      });
+
+      discardPeriodicTasks();
+    })
+  );
+
+  it('should open feedback dialog', fakeAsync(() => {
+      const testFeedbackRequest = {
+        feedbackCode: 'testCode',
+        description: 'description'
+      } as NewFeedback;
+
+      feedbackServiceSpy.getLastFeedbackCheck.and.returnValue(new Date().getTime() - (3600 * 1000 + 5 * 1000));
+      feedbackServiceSpy.requestFeedback.and.returnValue(of(testFeedbackRequest));
+
+      const notifications$ = provider.getNotifications().pipe(
+        shareReplay(1)
+      );
+
+      notifications$.subscribe();
+      jasmine.clock().tick(5000);
+
+      expect(feedbackServiceSpy.requestFeedback).toHaveBeenCalled();
+
+      readNotification(notifications$, notifications => {
+        expect(notifications.length).toBe(1);
+
+        notifications[0].open!();
+
+        expect(modalServiceSpy.openVoteModal).toHaveBeenCalledOnceWith(testFeedbackRequest);
+      });
+
+      discardPeriodicTasks();
+    })
+  );
+});

--- a/src/app/modules/feedback/services/feedback-notifications-provider.ts
+++ b/src/app/modules/feedback/services/feedback-notifications-provider.ts
@@ -1,0 +1,85 @@
+﻿import { NotificationsProvider } from '../../notifications/services/notifications-provider';
+import {
+  BehaviorSubject,
+  Observable,
+  shareReplay,
+  switchMap,
+  tap,
+  timer
+} from 'rxjs';
+import { NotificationMeta } from '../../notifications/models/notification.model';
+import { GuidGenerator } from '../../../shared/utils/guid';
+import { ModalService } from '../../../shared/services/modal.service';
+import { Injectable } from '@angular/core';
+import { FeedbackService } from './feedback.service';
+import {
+  filter,
+  map,
+  startWith
+} from 'rxjs/operators';
+import { mapWith } from '../../../shared/utils/observable-helper';
+import { addHours } from '../../../shared/utils/datetime';
+
+@Injectable()
+export class FeedbackNotificationsProvider implements NotificationsProvider {
+  private readonly readNotification$ = new BehaviorSubject<boolean>(false);
+
+  constructor(
+    private readonly modalService: ModalService,
+    private readonly feedbackService: FeedbackService
+  ) {
+  }
+
+  getNotifications(): Observable<NotificationMeta[]> {
+    const lastCheck = this.feedbackService.getLastFeedbackCheck();
+    if (!lastCheck) {
+      this.feedbackService.setLastFeedbackCheck();
+    }
+
+    const defaultDelayHours = 1;
+    const defaultDelayMilliseconds = defaultDelayHours * 3600 * 1000;
+
+    const now = new Date();
+    let startTime = now;
+    if (!!lastCheck) {
+      if ((now.getTime() - lastCheck) > defaultDelayMilliseconds) {
+        startTime = addHours(new Date(now), -defaultDelayHours);
+      }
+    }
+
+    return timer(startTime, defaultDelayMilliseconds).pipe(
+      tap(() => this.readNotification$.next(false)),
+      switchMap(() => this.feedbackService.requestFeedback()),
+      tap(() => this.feedbackService.setLastFeedbackCheck()),
+      filter(f => !!f),
+      mapWith(() => this.readNotification$, (feedback, isRead) => ({ feedback, isRead })),
+      map(s => {
+        if (s.isRead) {
+          return [];
+        }
+
+        return [
+          {
+            id: GuidGenerator.newGuid(),
+            date: new Date(),
+            title: 'Оценить приложение',
+            description: 'Поделитесь своим мнением о приложении',
+            showDate: true,
+            isRead: false,
+            open: () => this.modalService.openVoteModal({
+              feedbackCode: s.feedback!.feedbackCode,
+              description: s.feedback!.description
+            }),
+            markAsRead: () => this.markReadNotification()
+          } as NotificationMeta
+        ];
+      }),
+      shareReplay(1),
+      startWith([])
+    );
+  }
+
+  private markReadNotification() {
+    this.readNotification$.next(true);
+  }
+}

--- a/src/app/modules/feedback/services/feedback-notifications-provider.ts
+++ b/src/app/modules/feedback/services/feedback-notifications-provider.ts
@@ -19,6 +19,7 @@ import {
 } from 'rxjs/operators';
 import { mapWith } from '../../../shared/utils/observable-helper';
 import { addHours } from '../../../shared/utils/datetime';
+import { NewFeedback } from '../models/feedback.model';
 
 @Injectable()
 export class FeedbackNotificationsProvider implements NotificationsProvider {
@@ -40,10 +41,10 @@ export class FeedbackNotificationsProvider implements NotificationsProvider {
     const defaultDelayMilliseconds = defaultDelayHours * 3600 * 1000;
 
     const now = new Date();
-    let startTime = now;
+    let startTime = addHours(new Date(now), defaultDelayHours);
     if (!!lastCheck) {
       if ((now.getTime() - lastCheck) > defaultDelayMilliseconds) {
-        startTime = addHours(new Date(now), -defaultDelayHours);
+        startTime = now;
       }
     }
 
@@ -66,10 +67,14 @@ export class FeedbackNotificationsProvider implements NotificationsProvider {
             description: 'Поделитесь своим мнением о приложении',
             showDate: true,
             isRead: false,
-            open: () => this.modalService.openVoteModal({
-              feedbackCode: s.feedback!.feedbackCode,
-              description: s.feedback!.description
-            }),
+            open: () => {
+              const params: NewFeedback = {
+                feedbackCode: s.feedback!.feedbackCode,
+                description: s.feedback!.description
+              };
+
+              this.modalService.openVoteModal(params);
+            },
             markAsRead: () => this.markReadNotification()
           } as NotificationMeta
         ];

--- a/src/app/modules/feedback/services/feedback-notifications-provider.ts
+++ b/src/app/modules/feedback/services/feedback-notifications-provider.ts
@@ -72,7 +72,7 @@ export class FeedbackNotificationsProvider implements NotificationsProvider {
           }
           else {
             return this.feedbackService.requestFeedback().pipe(
-              map(x => ({ ...x, isRead: false } as UnansweredFeedback)),
+              map(x => ({ ...x, isRead: false, date: Date.now() } as UnansweredFeedback)),
               tap(x => this.feedbackService.setUnansweredFeedback(x))
             );
           }
@@ -83,7 +83,7 @@ export class FeedbackNotificationsProvider implements NotificationsProvider {
           return [
             {
               id: GuidGenerator.newGuid(),
-              date: new Date(),
+              date:  !!f.date ? new Date(f.date) : new Date(),
               title: 'Оценить приложение',
               description: 'Поделитесь своим мнением о приложении',
               showDate: true,

--- a/src/app/modules/feedback/services/feedback.service.spec.ts
+++ b/src/app/modules/feedback/services/feedback.service.spec.ts
@@ -1,0 +1,47 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FeedbackService } from './feedback.service';
+import { LocalStorageService } from '../../../shared/services/local-storage.service';
+import { ErrorHandlerService } from '../../../shared/services/handle-error/error-handler.service';
+import { HttpClient } from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+
+describe('FeedbackService', () => {
+  let service: FeedbackService;
+  let httpClient: HttpClient;
+  let httpClientController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        {
+          provide: LocalStorageService,
+          useValue: {
+            getItem: jasmine.createSpy('getItem').and.returnValue(undefined),
+            setItem: jasmine.createSpy('setItem').and.callThrough(),
+          }
+        },
+        {
+          provide: ErrorHandlerService,
+          useValue: {
+            handleError: jasmine.createSpy('handleError').and.callThrough()
+          }
+        }
+      ]
+    });
+
+    service = TestBed.inject(FeedbackService);
+    httpClient = TestBed.inject(HttpClient);
+    httpClientController = TestBed.inject(HttpTestingController);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/feedback/services/feedback.service.ts
+++ b/src/app/modules/feedback/services/feedback.service.ts
@@ -22,7 +22,7 @@ interface FeedbackMeta {
   providedIn: 'root'
 })
 export class FeedbackService {
-  private readonly baseUrl = environment.apiUrl + '/cmsapi/v1/astras';
+  private readonly baseUrl = environment.apiUrl + '/astras';
   private readonly feedbackLocalStorageKey = 'feedback';
 
   constructor(

--- a/src/app/modules/feedback/services/feedback.service.ts
+++ b/src/app/modules/feedback/services/feedback.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import {
+  NewFeedback,
+  SendFeedBackRequest,
+  SendFeedBackResponse
+} from '../models/feedback.model';
+import {
+  Observable,
+  take
+} from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { LocalStorageService } from '../../../shared/services/local-storage.service';
+import { ErrorHandlerService } from '../../../shared/services/handle-error/error-handler.service';
+import { catchHttpError } from '../../../shared/utils/observable-helper';
+
+interface FeedbackMeta {
+  lastCheck?: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FeedbackService {
+  private readonly baseUrl = environment.apiUrl + '/cmsapi/v1/astras';
+  private readonly feedbackLocalStorageKey = 'feedback';
+
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly localStorage: LocalStorageService,
+    private readonly errorHandlerService: ErrorHandlerService
+  ) {
+  }
+
+  getLastFeedbackCheck(): number | null {
+    const lastCheck = this.getSavedFeedbackMeta()?.lastCheck ?? null;
+
+    if (lastCheck) {
+      return lastCheck;
+    }
+
+    return null;
+  }
+
+  setLastFeedbackCheck() {
+    const lastCheck = this.getSavedFeedbackMeta()?.lastCheck ?? {};
+    this.saveFeedbackMeta({
+      ...lastCheck,
+      lastCheck: Date.now()
+    });
+  }
+
+  submitFeedback(feedback: SendFeedBackRequest): Observable<SendFeedBackResponse> {
+    return this.httpClient.post<SendFeedBackResponse>(
+      `${this.baseUrl}/rates`,
+      feedback
+    );
+  }
+
+  requestFeedback(): Observable<NewFeedback | null> {
+    return this.httpClient.get<NewFeedback | null>(`${this.baseUrl}/rates/actions/getNewRequest`).pipe(
+      catchHttpError<NewFeedback | null>(null, this.errorHandlerService),
+      take(1)
+    );
+  }
+
+  private getSavedFeedbackMeta(): FeedbackMeta | null {
+    return this.localStorage.getItem<FeedbackMeta>(this.feedbackLocalStorageKey) ?? null;
+  }
+
+  private saveFeedbackMeta(meta: FeedbackMeta) {
+    this.localStorage.setItem(this.feedbackLocalStorageKey, meta);
+  }
+}

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.html
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.html
@@ -1,0 +1,39 @@
+<div *ngIf="voteParams$ | async as voteParams">
+  <nz-modal
+    (nzOnCancel)="handleClose()"
+    [nzFooter]="null"
+    [nzVisible]='isVisible$ | async'
+    nzTitle="Оцените приложение"
+  >
+    <ng-container *nzModalContent>
+      <div>
+        <form *ngIf="form" [formGroup]="form" [nzLayout]="'vertical'" nz-form>
+          <nz-form-item>
+            <nz-form-label nzFor="rate">{{voteParams.description}}</nz-form-label>
+            <nz-form-control>
+              <nz-rate (ngModelChange)="checkAskComment()" [nzCount]="maxStarsCount" formControlName="rate"></nz-rate>
+            </nz-form-control>
+          </nz-form-item>
+          <nz-form-item>
+            <nz-form-label nzFor="comment">Комментарий</nz-form-label>
+            <nz-form-control
+              [nzValidateStatus]="askComment ? 'warning' : 'success'"
+              [nzWarningTip]="askComment ? 'Пожалуйста, расскажите что нам следует доработать.' : ''">
+              <nz-textarea-count [nzMaxCharacterCount]="commentMaxLength">
+                <textarea (ngModelChange)="checkAskComment()" formControlName="comment" nz-input rows="4"></textarea>
+              </nz-textarea-count>
+            </nz-form-control>
+          </nz-form-item>
+        </form>
+        <div class="submit-button-container">
+          <button
+            (click)="submitFeedback()"
+            [attr.disabled]="form?.valid === false ? '' : null" nz-button
+            nzType="primary">
+            Отправить отзыв
+          </button>
+        </div>
+      </div>
+    </ng-container>
+  </nz-modal>
+</div>

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.html
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.html
@@ -28,8 +28,8 @@
         <div class="submit-button-container">
           <button
             (click)="submitFeedback()"
-            [attr.disabled]="form?.valid === false ? '' : null" nz-button
-            nzType="primary">
+            [attr.disabled]="form?.valid === false ? '' : null"
+            class="ant-btn ant-btn-primary">
             Отправить отзыв
           </button>
         </div>

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.less
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.less
@@ -1,0 +1,5 @@
+.submit-button-container {
+  display: flex;
+  justify-content: center;
+  padding-top: 10px;
+}

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
@@ -1,0 +1,48 @@
+import {
+  ComponentFixture,
+  TestBed
+} from '@angular/core/testing';
+import { FeedbackWidgetComponent } from './feedback-widget.component';
+import { FeedbackService } from '../../services/feedback.service';
+import { of } from 'rxjs';
+import { ModalService } from '../../../../shared/services/modal.service';
+import { NewFeedback } from '../../models/feedback.model';
+
+
+describe('FeedbackWidgetComponent', () => {
+  let component: FeedbackWidgetComponent;
+  let fixture: ComponentFixture<FeedbackWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FeedbackWidgetComponent],
+      providers: [
+        {
+          provide: FeedbackService,
+          useValue: {
+            submitFeedback: jasmine.createSpy('submitFeedback').and.returnValue(of({}))
+          }
+        },
+        {
+          provide: ModalService,
+          useValue: {
+            shouldShowVoteModal$: of(true),
+            voteParams$: of({ feedbackCode: 'testCode', description: '' } as NewFeedback),
+            closeVoteModal: jasmine.createSpy('closeVoteModal').and.callThrough()
+          }
+        }
+      ]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FeedbackWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
@@ -9,6 +9,7 @@ import { ModalService } from '../../../../shared/services/modal.service';
 import { NewFeedback } from '../../models/feedback.model';
 import { FeedbackModule } from '../../feedback.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { NzNotificationService } from 'ng-zorro-antd/notification';
 
 
 describe('FeedbackWidgetComponent', () => {
@@ -35,6 +36,12 @@ describe('FeedbackWidgetComponent', () => {
             shouldShowVoteModal$: of(true),
             voteParams$: of({ code: 'testCode', description: '' } as NewFeedback),
             closeVoteModal: jasmine.createSpy('closeVoteModal').and.callThrough()
+          }
+        },
+        {
+          provide: NzNotificationService,
+          useValue: {
+            success: jasmine.createSpy('success').and.callThrough()
           }
         }
       ]

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
@@ -33,7 +33,7 @@ describe('FeedbackWidgetComponent', () => {
           provide: ModalService,
           useValue: {
             shouldShowVoteModal$: of(true),
-            voteParams$: of({ feedbackCode: 'testCode', description: '' } as NewFeedback),
+            voteParams$: of({ code: 'testCode', description: '' } as NewFeedback),
             closeVoteModal: jasmine.createSpy('closeVoteModal').and.callThrough()
           }
         }

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.spec.ts
@@ -7,6 +7,8 @@ import { FeedbackService } from '../../services/feedback.service';
 import { of } from 'rxjs';
 import { ModalService } from '../../../../shared/services/modal.service';
 import { NewFeedback } from '../../models/feedback.model';
+import { FeedbackModule } from '../../feedback.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 
 describe('FeedbackWidgetComponent', () => {
@@ -15,6 +17,10 @@ describe('FeedbackWidgetComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [
+        FeedbackModule,
+        NoopAnimationsModule
+      ],
       declarations: [FeedbackWidgetComponent],
       providers: [
         {

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.ts
@@ -1,0 +1,101 @@
+import {
+  Component,
+  OnDestroy,
+  OnInit
+} from '@angular/core';
+import {
+  Observable,
+  of,
+  shareReplay,
+  Subject,
+  takeUntil
+} from 'rxjs';
+import { ModalService } from '../../../../shared/services/modal.service';
+import {
+  FormControl,
+  FormGroup,
+  Validators
+} from '@angular/forms';
+import { FeedbackService } from '../../services/feedback.service';
+import {
+  filter,
+  finalize
+} from 'rxjs/operators';
+import { NewFeedback } from '../../models/feedback.model';
+
+@Component({
+  selector: 'ats-feedback-widget',
+  templateUrl: './feedback-widget.component.html',
+  styleUrls: ['./feedback-widget.component.less']
+})
+export class FeedbackWidgetComponent implements OnInit, OnDestroy {
+  isVisible$: Observable<boolean> = of(false);
+  readonly commentMaxLength = 5000;
+  readonly maxStarsCount = 5;
+  askComment = false;
+  form?: FormGroup;
+
+  voteParams$!: Observable<NewFeedback>;
+
+  private readonly destroy$: Subject<boolean> = new Subject<boolean>();
+
+  constructor(
+    private readonly modalService: ModalService,
+    private readonly feedbackService: FeedbackService
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.isVisible$ = this.modalService.shouldShowVoteModal$;
+
+    this.voteParams$ = this.modalService.voteParams$.pipe(
+      filter((x): x is NewFeedback => !!x),
+      shareReplay(1)
+    );
+
+    this.voteParams$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(params => {
+      this.initForm(params);
+    });
+  }
+
+  handleClose() {
+    this.modalService.closeVoteModal();
+  }
+
+  initForm(params: NewFeedback) {
+    this.askComment = false;
+    this.form = new FormGroup({
+      rate: new FormControl(null, Validators.required),
+      comment: new FormControl(null, [Validators.maxLength(this.commentMaxLength)]),
+      feedbackCode: new FormControl(params.feedbackCode)
+    });
+  }
+
+  submitFeedback() {
+    if (!this.form?.valid) {
+      return;
+    }
+
+    if (!this.askComment) {
+      this.checkAskComment();
+      if (this.askComment) {
+        return;
+      }
+    }
+
+    this.feedbackService.submitFeedback(this.form.value).pipe(
+      finalize(() => this.modalService.closeVoteModal())
+    ).subscribe();
+  }
+
+  checkAskComment() {
+    this.askComment = this.form?.value.rate < this.maxStarsCount && (this.form?.value.comment ?? '').length === 0;
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next(true);
+    this.destroy$.complete();
+  }
+}

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.ts
@@ -69,7 +69,7 @@ export class FeedbackWidgetComponent implements OnInit, OnDestroy {
     this.form = new FormGroup({
       rate: new FormControl(null, Validators.required),
       comment: new FormControl(null, [Validators.maxLength(this.commentMaxLength)]),
-      feedbackCode: new FormControl(params.feedbackCode)
+      code: new FormControl(params.code)
     });
   }
 
@@ -86,7 +86,10 @@ export class FeedbackWidgetComponent implements OnInit, OnDestroy {
     }
 
     this.feedbackService.submitFeedback(this.form.value).pipe(
-      finalize(() => this.modalService.closeVoteModal())
+      finalize(() => {
+        this.modalService.closeVoteModal();
+        this.feedbackService.removeUnansweredFeedback();
+      })
     ).subscribe();
   }
 

--- a/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.ts
+++ b/src/app/modules/feedback/widgets/feedback-widget/feedback-widget.component.ts
@@ -22,6 +22,7 @@ import {
   finalize
 } from 'rxjs/operators';
 import { NewFeedback } from '../../models/feedback.model';
+import { NzNotificationService } from 'ng-zorro-antd/notification';
 
 @Component({
   selector: 'ats-feedback-widget',
@@ -41,7 +42,8 @@ export class FeedbackWidgetComponent implements OnInit, OnDestroy {
 
   constructor(
     private readonly modalService: ModalService,
-    private readonly feedbackService: FeedbackService
+    private readonly feedbackService: FeedbackService,
+    private readonly notificationService: NzNotificationService
   ) {
   }
 
@@ -90,7 +92,9 @@ export class FeedbackWidgetComponent implements OnInit, OnDestroy {
         this.modalService.closeVoteModal();
         this.feedbackService.removeUnansweredFeedback();
       })
-    ).subscribe();
+    ).subscribe( ()=> {
+      this.notificationService.success('Оценка приложения', 'Спасибо, Ваш голос важен для нас.');
+    });
   }
 
   checkAskComment() {

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.html
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.html
@@ -1,0 +1,3 @@
+<nz-badge [nzCount]="2" [nzOffset]="[-2, 10]">
+  <button nz-button><i nz-icon nzType="bell" nzTheme="outline"></i></button>
+</nz-badge>

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.html
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.html
@@ -1,3 +1,63 @@
-<nz-badge [nzCount]="2" [nzOffset]="[-2, 10]">
-  <button nz-button><i nz-icon nzType="bell" nzTheme="outline"></i></button>
+<nz-badge [(nzPopoverVisible)]="isTableVisible" [nzCount]="(notReadNotificationsCount$ | async) || 0"
+          [nzOffset]="[-2, 10]"
+          [nzPopoverContent]="contentTemplate"
+          [nzPopoverTitle]="titleTemplate"
+          nz-popover
+          nzPopoverPlacement="leftBottom"
+          nzPopoverTrigger="click"
+>
+  <button nz-button>
+    <i nz-icon nzTheme="outline" nzType="bell"></i>
+  </button>
 </nz-badge>
+
+<ng-template #titleTemplate>
+  <div class="dialog-title">
+    <div>
+      <h3>Уведомления</h3>
+    </div>
+    <div>
+      <button (click)="isTableVisible = false" aria-label="Close" nz-button>
+        <i [nzTheme]="'outline'" nz-icon nzType="close"></i>
+      </button>
+    </div>
+  </div>
+</ng-template>
+
+<ng-template #contentTemplate>
+  <nz-table #table
+            [nzData]="(sortedNotifications$ | async)!"
+            [nzPageSize]="5"
+            class="notifications-table"
+  >
+    <tbody>
+    <tr *ngFor="let data of table.data">
+      <td>
+        <div (click)="clickNotification(data)"
+             [ngClass]="{
+             'notification': true,
+             'read': data.isRead
+             }"
+        >
+          <div class="read-status">
+            <nz-badge [nzStatus]="data.isRead ? 'default' : 'processing'"></nz-badge>
+          </div>
+          <div class="main">
+            <div class="header">
+              <div class="title">
+                <span nz-typography><strong>{{data.title}}</strong></span>
+              </div>
+              <div *ngIf="data.showDate" class="date">
+                <span>{{data.date | date : 'dd MMM в HH:mm' :undefined: 'ru'}}</span>
+              </div>
+            </div>
+            <div class="body">
+              <span nz-typography nzType="secondary">{{data.description}}</span>
+            </div>
+          </div>
+        </div>
+      </td>
+    </tr>
+    </tbody>
+  </nz-table>
+</ng-template>

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.html
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.html
@@ -25,9 +25,12 @@
 </ng-template>
 
 <ng-template #contentTemplate>
+  <ng-container *ngIf="sortedNotifications$ | async as notifications">
   <nz-table #table
-            [nzData]="(sortedNotifications$ | async)!"
+            [nzData]="notifications"
             [nzPageSize]="5"
+            [nzShowPagination]="notifications.length > table.nzPageSize"
+            [nzPaginationType]="'small'"
             class="notifications-table"
   >
     <tbody>
@@ -60,4 +63,5 @@
     </tr>
     </tbody>
   </nz-table>
+  </ng-container>
 </ng-template>

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.less
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.less
@@ -1,0 +1,88 @@
+@import (reference) '/src/styles.less';
+
+@width: 350px;
+
+::ng-deep .ant-popover-inner-content {
+  padding: 8px;
+}
+
+.dialog-title {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+
+  button {
+    margin-right: -10px;
+    border: none;
+    opacity: 0.5;
+
+    &:hover, &:focus {
+      color: @icon-color-hover;
+      text-decoration: none;
+      opacity: 1;
+    }
+  }
+}
+
+.notifications-table {
+  width: @width;
+
+  ::ng-deep .ant-table {
+    background: transparent;
+
+    table {
+      .ant-table-tbody {
+        td {
+          padding: 0;
+          border: none;
+
+          .ant-card {
+            background-color: transparent;
+          }
+        }
+      }
+
+    }
+  }
+
+  .notification {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    border-bottom: 1px solid @border-color-base;
+    padding-top: 3px;
+    padding-bottom: 5px;
+    width: @width;
+
+    &.read {
+      cursor: initial;
+    }
+
+    .read-status {
+      padding-left: 3px;
+    }
+
+    .main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+
+      .header {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+
+        .date {
+          margin-left: auto;
+          white-space: nowrap;
+        }
+      }
+
+      .body {
+        display: inline-flex;
+        flex-direction: row;
+        padding-top: 3px;
+      }
+    }
+  }
+}

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.spec.ts
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotificationButtonComponent } from './notification-button.component';
+
+describe('NotificationButtonComponent', () => {
+  let component: NotificationButtonComponent;
+  let fixture: ComponentFixture<NotificationButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ NotificationButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NotificationButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.spec.ts
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NotificationButtonComponent } from './notification-button.component';
+import { sharedModuleImportForTests } from '../../../../shared/utils/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('NotificationButtonComponent', () => {
   let component: NotificationButtonComponent;
@@ -8,7 +10,11 @@ describe('NotificationButtonComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ NotificationButtonComponent ]
+      declarations: [ NotificationButtonComponent ],
+      imports:[
+        NoopAnimationsModule,
+        ...sharedModuleImportForTests
+      ]
     })
     .compileComponents();
   });

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.ts
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.ts
@@ -1,12 +1,52 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+import { NotificationsService } from '../../services/notifications.service';
+import {
+  Observable,
+  shareReplay
+} from 'rxjs';
+import { NotificationMeta } from '../../models/notification.model';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'ats-notification-button',
   templateUrl: './notification-button.component.html',
   styleUrls: ['./notification-button.component.less']
 })
-export class NotificationButtonComponent {
+export class NotificationButtonComponent implements OnInit {
+  isTableVisible = false;
+  private notifications$!: Observable<NotificationMeta[]>;
 
-  constructor() {
+  constructor(private readonly notificationsService: NotificationsService) {
+  }
+
+  get notReadNotificationsCount$(): Observable<number> {
+    return this.notifications$.pipe(
+      map(n => n.filter(x => !x.isRead).length),
+    );
+  }
+
+  get sortedNotifications$(): Observable<NotificationMeta[]> {
+    return this.notifications$.pipe(
+      map(n => [...n]),
+      map(n => n.sort((a, b) => b.date.getTime() - a.date.getTime()))
+    );
+  }
+
+  ngOnInit(): void {
+    this.notifications$ = this.notificationsService.getNotifications().pipe(
+      shareReplay(1)
+    );
+  }
+
+  markAsRead(notification: NotificationMeta) {
+    notification.markAsRead?.();
+  }
+
+  clickNotification(notification: NotificationMeta) {
+    notification.markAsRead?.();
+    notification.open?.();
   }
 }

--- a/src/app/modules/notifications/components/notification-button/notification-button.component.ts
+++ b/src/app/modules/notifications/components/notification-button/notification-button.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ats-notification-button',
+  templateUrl: './notification-button.component.html',
+  styleUrls: ['./notification-button.component.less']
+})
+export class NotificationButtonComponent {
+
+  constructor() {
+  }
+}

--- a/src/app/modules/notifications/models/notification.model.ts
+++ b/src/app/modules/notifications/models/notification.model.ts
@@ -1,0 +1,10 @@
+﻿export interface NotificationMeta {
+  id: string;
+  date: Date;
+  title: string;
+  description: string;
+  isRead: boolean;
+  showDate: boolean;
+  open?(): void;
+  markAsRead?() : void
+}

--- a/src/app/modules/notifications/notifications.module.ts
+++ b/src/app/modules/notifications/notifications.module.ts
@@ -4,7 +4,10 @@ import { NotificationButtonComponent } from './components/notification-button/no
 import { NzBadgeModule } from 'ng-zorro-antd/badge';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzIconModule } from 'ng-zorro-antd/icon';
-
+import { NzPopoverModule } from 'ng-zorro-antd/popover';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzTableModule } from 'ng-zorro-antd/table';
+import { NzTypographyModule } from 'ng-zorro-antd/typography';
 
 
 @NgModule({
@@ -18,7 +21,12 @@ import { NzIconModule } from 'ng-zorro-antd/icon';
     CommonModule,
     NzBadgeModule,
     NzButtonModule,
-    NzIconModule
+    NzIconModule,
+    NzPopoverModule,
+    NzCardModule,
+    NzTableModule,
+    NzTypographyModule
   ]
 })
-export class NotificationsModule { }
+export class NotificationsModule {
+}

--- a/src/app/modules/notifications/notifications.module.ts
+++ b/src/app/modules/notifications/notifications.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NotificationButtonComponent } from './components/notification-button/notification-button.component';
+import { NzBadgeModule } from 'ng-zorro-antd/badge';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+
+
+
+@NgModule({
+  declarations: [
+    NotificationButtonComponent
+  ],
+  exports: [
+    NotificationButtonComponent
+  ],
+  imports: [
+    CommonModule,
+    NzBadgeModule,
+    NzButtonModule,
+    NzIconModule
+  ]
+})
+export class NotificationsModule { }

--- a/src/app/modules/notifications/services/notifications-provider.ts
+++ b/src/app/modules/notifications/services/notifications-provider.ts
@@ -1,0 +1,13 @@
+﻿import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+import { NotificationMeta } from '../models/notification.model';
+
+export interface NotificationHandler {
+
+}
+
+export interface NotificationsProvider extends NotificationHandler {
+  getNotifications(): Observable<NotificationMeta[]>;
+}
+
+export const NOTIFICATIONS_PROVIDER = new InjectionToken<NotificationsProvider[]>('NotificationsProvider');

--- a/src/app/modules/notifications/services/notifications.service.spec.ts
+++ b/src/app/modules/notifications/services/notifications.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NotificationsService } from './notifications.service';
+import { sharedModuleImportForTests } from '../../../shared/utils/testing';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports:[...sharedModuleImportForTests]
+    });
+    service = TestBed.inject(NotificationsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/notifications/services/notifications.service.ts
+++ b/src/app/modules/notifications/services/notifications.service.ts
@@ -1,0 +1,43 @@
+import {
+  Inject,
+  Injectable
+} from '@angular/core';
+import {
+  NOTIFICATIONS_PROVIDER,
+  NotificationsProvider
+} from './notifications-provider';
+import {
+  combineLatest,
+  Observable
+} from 'rxjs';
+import { NotificationMeta } from '../models/notification.model';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationsService {
+  private readonly notifications: Observable<NotificationMeta[]>;
+
+  constructor(
+    @Inject(NOTIFICATIONS_PROVIDER)
+    private readonly providers: NotificationsProvider[]
+  ) {
+    const allNotifications: Observable<NotificationMeta[]>[] = [];
+
+    const allProviders = providers ?? [];
+    for (let i = 0; i < allProviders.length; i++) {
+      const provider = allProviders[i];
+
+      allNotifications.push(provider.getNotifications());
+    }
+
+    this.notifications = combineLatest(allNotifications).pipe(
+      map(notifications => notifications.reduce((previousValue, currentValue) => [...previousValue, ...currentValue], []))
+    );
+  }
+
+  getNotifications(): Observable<NotificationMeta[]> {
+    return this.notifications;
+  }
+}

--- a/src/app/modules/notifications/services/providers/test-notifications-provider.ts
+++ b/src/app/modules/notifications/services/providers/test-notifications-provider.ts
@@ -17,7 +17,8 @@ export class TestNotificationsProvider implements NotificationsProvider {
         description: 'Description Description Description Description Description Description',
         isRead: false,
         showDate: true,
-        open: () => {}
+        open: () => {
+        }
       },
       {
         id: '2',
@@ -59,6 +60,22 @@ export class TestNotificationsProvider implements NotificationsProvider {
         isRead: false,
         showDate: true
       },
+      {
+        id: '7',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 6)),
+        title: 'Test 7',
+        description: 'Description Description Description Description Description Description',
+        isRead: false,
+        showDate: true
+      },
+      {
+        id: '8',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 7)),
+        title: 'Test 8',
+        description: 'Description Description Description Description Description Description',
+        isRead: false,
+        showDate: true
+      }
     ]);
   }
 

--- a/src/app/modules/notifications/services/providers/test-notifications-provider.ts
+++ b/src/app/modules/notifications/services/providers/test-notifications-provider.ts
@@ -1,0 +1,65 @@
+﻿import { NotificationsProvider } from '../notifications-provider';
+import {
+  Observable,
+  of
+} from 'rxjs';
+import { NotificationMeta } from '../../models/notification.model';
+
+export class TestNotificationsProvider implements NotificationsProvider {
+  getNotifications(): Observable<NotificationMeta[]> {
+    const now = new Date();
+
+    return of([
+      {
+        id: '1',
+        date: now,
+        title: 'Long long long long long long long long long long title',
+        description: 'Description Description Description Description Description Description',
+        isRead: false,
+        showDate: true,
+        open: () => {}
+      },
+      {
+        id: '2',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 10)),
+        title: 'Test 2',
+        description: 'Description Description Description Description Description Description',
+        isRead: true,
+        showDate: true
+      },
+      {
+        id: '3',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 2)),
+        title: 'Test 3',
+        description: 'Description Description Description Description Description Description',
+        isRead: false,
+        showDate: true
+      },
+      {
+        id: '4',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 3)),
+        title: 'Test 4',
+        description: '',
+        isRead: false,
+        showDate: false
+      },
+      {
+        id: '5',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 4)),
+        title: 'Test 5',
+        description: 'Description Description Description Description Description Description',
+        isRead: false,
+        showDate: true
+      },
+      {
+        id: '6',
+        date: new Date(new Date().setMinutes(now.getMinutes() - 5)),
+        title: 'Test 6',
+        description: 'Description Description Description Description Description Description',
+        isRead: false,
+        showDate: true
+      },
+    ]);
+  }
+
+}

--- a/src/app/shared/services/modal.service.ts
+++ b/src/app/shared/services/modal.service.ts
@@ -7,6 +7,7 @@ import { PortfolioKey } from '../models/portfolio-key.model';
 import { getSelectedPortfolio } from '../../store/portfolios/portfolios.selectors';
 import { NewsListItem } from "../../modules/news/models/news.model";
 import { WidgetNames } from "../models/enums/widget-names";
+import { NewFeedback } from '../../modules/feedback/models/feedback.model';
 
 @Injectable({
   providedIn: 'root'
@@ -25,6 +26,9 @@ export class ModalService {
 
   private shouldShowTerminalSettingsModal = new BehaviorSubject<boolean>(false);
 
+  private shouldShowVoteModal = new BehaviorSubject<boolean>(false);
+  private voteParams = new BehaviorSubject<NewFeedback | null>(null);
+
   private newsItem = new BehaviorSubject<NewsListItem | null>(null);
   private shouldShowNewsModal = new BehaviorSubject<boolean>(false);
 
@@ -40,7 +44,11 @@ export class ModalService {
   shouldShowTerminalSettingsModal$ = this.shouldShowTerminalSettingsModal.asObservable();
 
   newsItem$ = this.newsItem.asObservable();
+
   shouldShowNewsModal$ = this.shouldShowNewsModal.asObservable();
+
+  shouldShowVoteModal$ = this.shouldShowVoteModal.asObservable();
+  voteParams$ = this.voteParams.asObservable();
 
   constructor(private store: Store) {
     this.store.select(getSelectedPortfolio).subscribe(p => {
@@ -80,6 +88,11 @@ export class ModalService {
     this.newsItem.next(newsItem);
   }
 
+  openVoteModal(voteParams: NewFeedback) {
+    this.voteParams.next(voteParams);
+    this.shouldShowVoteModal.next(true);
+  }
+
   closeTerminalSettingsModal() {
     this.shouldShowTerminalSettingsModal.next(false);
   }
@@ -98,5 +111,10 @@ export class ModalService {
 
   closeNewsModal() {
     this.shouldShowNewsModal.next(false);
+  }
+
+  closeVoteModal() {
+    this.shouldShowVoteModal.next(false);
+    this.voteParams.next(null);
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -50,7 +50,6 @@ import { NzInputModule } from "ng-zorro-antd/input";
 import { ShortNumberPipe } from './pipes/short-number.pipe';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { NOTIFICATIONS_PROVIDER } from '../modules/notifications/services/notifications-provider';
-import { TestNotificationsProvider } from '../modules/notifications/services/providers/test-notifications-provider';
 import { FeedbackNotificationsProvider } from '../modules/feedback/services/feedback-notifications-provider';
 
 
@@ -163,7 +162,6 @@ import { FeedbackNotificationsProvider } from '../modules/feedback/services/feed
     },
     { provide: ERROR_HANDLER, useClass: HttpErrorHandler, multi: true },
     { provide: ERROR_HANDLER, useClass: LogErrorHandler, multi: true },
-    { provide: NOTIFICATIONS_PROVIDER, useClass: TestNotificationsProvider, multi: true },
     { provide: NOTIFICATIONS_PROVIDER, useClass: FeedbackNotificationsProvider, multi: true }
   ],
 })

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -48,6 +48,7 @@ import { ColorChromeModule } from "ngx-color/chrome";
 import { NzPopoverModule } from "ng-zorro-antd/popover";
 import { NzInputModule } from "ng-zorro-antd/input";
 import { ShortNumberPipe } from './pipes/short-number.pipe';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
 
 
 @NgModule({
@@ -100,7 +101,8 @@ import { ShortNumberPipe } from './pipes/short-number.pipe';
         NzRadioModule,
         ColorChromeModule,
         NzPopoverModule,
-        NzInputModule
+        NzInputModule,
+        NzSpaceModule,
     ],
   exports: [
     // Ng zorro
@@ -133,6 +135,7 @@ import { ShortNumberPipe } from './pipes/short-number.pipe';
     NzTypographyModule,
     NzRadioModule,
     NzPopoverModule,
+    NzSpaceModule,
     // modules
     CommonModule,
     FormsModule,

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -51,6 +51,7 @@ import { ShortNumberPipe } from './pipes/short-number.pipe';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { NOTIFICATIONS_PROVIDER } from '../modules/notifications/services/notifications-provider';
 import { TestNotificationsProvider } from '../modules/notifications/services/providers/test-notifications-provider';
+import { FeedbackNotificationsProvider } from '../modules/feedback/services/feedback-notifications-provider';
 
 
 @NgModule({
@@ -162,7 +163,8 @@ import { TestNotificationsProvider } from '../modules/notifications/services/pro
     },
     { provide: ERROR_HANDLER, useClass: HttpErrorHandler, multi: true },
     { provide: ERROR_HANDLER, useClass: LogErrorHandler, multi: true },
-    { provide: NOTIFICATIONS_PROVIDER, useClass: TestNotificationsProvider, multi: true }
+    { provide: NOTIFICATIONS_PROVIDER, useClass: TestNotificationsProvider, multi: true },
+    { provide: NOTIFICATIONS_PROVIDER, useClass: FeedbackNotificationsProvider, multi: true }
   ],
 })
 export class SharedModule {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -49,6 +49,8 @@ import { NzPopoverModule } from "ng-zorro-antd/popover";
 import { NzInputModule } from "ng-zorro-antd/input";
 import { ShortNumberPipe } from './pipes/short-number.pipe';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NOTIFICATIONS_PROVIDER } from '../modules/notifications/services/notifications-provider';
+import { TestNotificationsProvider } from '../modules/notifications/services/providers/test-notifications-provider';
 
 
 @NgModule({
@@ -159,7 +161,8 @@ import { NzSpaceModule } from 'ng-zorro-antd/space';
       multi: true
     },
     { provide: ERROR_HANDLER, useClass: HttpErrorHandler, multi: true },
-    { provide: ERROR_HANDLER, useClass: LogErrorHandler, multi: true }
+    { provide: ERROR_HANDLER, useClass: LogErrorHandler, multi: true },
+    { provide: NOTIFICATIONS_PROVIDER, useClass: TestNotificationsProvider, multi: true }
   ],
 })
 export class SharedModule {

--- a/src/app/shared/utils/datetime.ts
+++ b/src/app/shared/utils/datetime.ts
@@ -36,6 +36,17 @@ export function addHours(date: Date, hours: number) : Date {
 }
 
 /**
+ * Adding minutes to provided date
+ *
+ * @param {Date} date date
+ * @param {number} minutes number of minutes, negative if you need to substract
+ * @return {Date} updated date
+ */
+export function addMinutes(date: Date, minutes: number) : Date {
+  return new Date(date.setMinutes(date.getMinutes() + minutes));
+}
+
+/**
  * Adding days to provided date
  *
  * @param {Date} date


### PR DESCRIPTION
Fixes #452 

# Description

Добавлено отображение оповещений. 
Добавлены оповещения для оценки приложения.

# Testing

При первом запуске в localStorage браузера создается поле:
![image](https://user-images.githubusercontent.com/29191749/191175275-d860c53c-f243-4cb2-81df-655660cc813a.png)
 Сохраняется время последней проверки в unix формате. 

Дальнейшие периоды проверки отсчитываются от этого времени если разница между текущим временем и lastCheck больше 1 часа, то следующая проверка будет выполнена через 5 мин.

lastCheck можно изменять для целей проверки - чтобы не жда 1 час, надо поставить это время в прошлом.

Так же сохраняется последний не отвеченный фидбэк. Для этого используется поле 
![image](https://user-images.githubusercontent.com/29191749/191177220-2c4b21b3-ffc6-463d-aa04-3fc7a699da8a.png)

Если есть неотвеченный фидбэк, то будет показан он, запроса к API не будет.
После ответа неотвеченный фидбэк обнуляется 

# Risk

No major changes

# Do you agree with those?
- [x] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [x] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
