### PR TITLE
centered widget name, move badge left

### DIFF
--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.html
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.html
@@ -1,5 +1,6 @@
 <div class='panel' *ngIf="settings$ | async as s">
-  <button *ngIf="hasSettings" nz-button nzSize="small" (click)="switchSettings($event)">
+  <div class="buttons-group">
+    <button *ngIf="hasSettings" nz-button nzSize="small" (click)="switchSettings($event)">
     <i nz-icon
       nzType="setting"
       [nzTheme]="'fill'"
@@ -7,12 +8,6 @@
       [title]="joyrideContent.step8.title"
       [text]="joyrideContent.step8.text"></i>
   </button>
-  <label
-    class="title"
-    nz-popover
-    nzPopoverPlacement="bottom"
-    [nzPopoverContent]="s.title"
-  >
     <nz-badge
       *ngIf="s.badgeColor &&
         (terminalSettings$ | async)?.badgesBind &&
@@ -21,9 +16,8 @@
       [nzDropdownMenu]="badgesMenu"
       [nzColor]="s.badgeColor"
       [class.square-badge]="['BlotterSettings', 'InstrumentSelectSettings', 'AllInstrumentsSettings'].includes(s.settingsType!)"
+      nzSize="small"
     ></nz-badge>
-
-    {{s.title}}
 
     <nz-dropdown-menu #badgesMenu="nzDropdownMenu">
       <ul nz-menu class="badge-menu">
@@ -35,8 +29,16 @@
         </li>
       </ul>
     </nz-dropdown-menu>
+  </div>
+  <label
+    class="title"
+    nz-popover
+    nzPopoverPlacement="bottom"
+    [nzPopoverContent]="s.title"
+  >
+    {{s.title}}
   </label>
-  <div class="right-buttons">
+  <div class="buttons-group">
     <button *ngIf='s.linkToActive !== undefined' nz-button nzSize="small"
       (mousedown)="linkToActive($event, !s.linkToActive)"
       (touchstart)="linkToActive($event, !s.linkToActive)"

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.less
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.less
@@ -53,11 +53,17 @@ button {
     margin-left: 3px;
   }
 
+  .ant-badge-status-dot {
+    width: 10px;
+    height: 10px;
+  }
+
   .square-badge .ant-badge-status-dot {
     border-radius: 0;
   }
 }
 
-.right-buttons {
+.buttons-group {
   display: flex;
+  align-items: center;
 }

--- a/src/app/modules/dashboard/components/widget-header/widget-header.component.less
+++ b/src/app/modules/dashboard/components/widget-header/widget-header.component.less
@@ -56,6 +56,7 @@ button {
   .ant-badge-status-dot {
     width: 10px;
     height: 10px;
+    margin-bottom: 1px;
   }
 
   .square-badge .ant-badge-status-dot {


### PR DESCRIPTION
Fixes #450

# Description

centered widget name, move badge left

# Testing

open widgets with and without settings
turn on badges binding

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
