### PR TITLE
fix auto align setting field

### DIFF
--- a/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.html
+++ b/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.html
@@ -136,17 +136,12 @@
           </nz-form-control>
           <nz-form-label nzFor="instrumentGroup" class="auto-align-label">
             Интервал автоматического выравнивания стакана, сек.
-            <span
-              nz-icon
-              nz-popover
-              nzPopoverTitle="Введите '0' или оставьте поле пустым, чтобы отключить авто-выравнивание"
-              nzType="info-circle"
-              nzTheme="outline"
-            >
-            </span>
           </nz-form-label>
           <nz-form-control nzErrorTip="Значение должно быть от {{validationOptions.autoAlignIntervalSec.min}} до {{validationOptions.autoAlignIntervalSec.max}}">
             <input (mousedown)="$event.stopPropagation()" atsNumerical class='ant-input' formControlName="autoAlignIntervalSec"/>
+            <span nz-typography nzType="secondary">
+              Введите '0' или оставьте поле пустым, чтобы отключить авто-выравнивание
+            </span>
           </nz-form-control>
         </nz-form-item>
       </nz-collapse-panel>

--- a/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.html
+++ b/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.html
@@ -134,7 +134,17 @@
           <nz-form-control nzErrorTip="Группа">
             <input (mousedown)="$event.stopPropagation()" class='ant-input' formControlName="instrumentGroup" placeholder="Режим торгов"/>
           </nz-form-control>
-          <nz-form-label nzFor="instrumentGroup">Интервал автоматического выравнивания стакана, сек.</nz-form-label>
+          <nz-form-label nzFor="instrumentGroup" class="auto-align-label">
+            Интервал автоматического выравнивания стакана, сек.
+            <span
+              nz-icon
+              nz-popover
+              nzPopoverTitle="Введите '0' или оставьте поле пустым, чтобы отключить авто-выравнивание"
+              nzType="info-circle"
+              nzTheme="outline"
+            >
+            </span>
+          </nz-form-label>
           <nz-form-control nzErrorTip="Значение должно быть от {{validationOptions.autoAlignIntervalSec.min}} до {{validationOptions.autoAlignIntervalSec.max}}">
             <input (mousedown)="$event.stopPropagation()" atsNumerical class='ant-input' formControlName="autoAlignIntervalSec"/>
           </nz-form-control>

--- a/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.less
+++ b/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.less
@@ -1,3 +1,13 @@
+::ng-deep {
+  .auto-align-label label {
+    display: block;
+
+    .anticon {
+      vertical-align: baseline;
+    }
+  }
+}
+
 nz-form-item {
   &.compact {
     margin: 0

--- a/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.ts
+++ b/src/app/modules/orderbook/components/scalper-order-book-settings/scalper-order-book-settings.component.ts
@@ -73,7 +73,7 @@ export class ScalperOrderBookSettingsComponent implements OnInit, OnDestroy {
       }
     },
     autoAlignIntervalSec: {
-      min: 1,
+      min: 0,
       max: 600
     }
   };
@@ -141,7 +141,7 @@ export class ScalperOrderBookSettingsComponent implements OnInit, OnDestroy {
         ),
         volumeHighlightFullness: Number(this.form.value.volumeHighlightFullness),
         workingVolumes: this.form.value.workingVolumes.map((wv: string) => Number(wv)),
-        autoAlignIntervalSec: !!this.form.value.autoAlignIntervalSec ? Number(this.form.value.autoAlignIntervalSec) : null
+        autoAlignIntervalSec: !!(+this.form.value.autoAlignIntervalSec) ? Number(this.form.value.autoAlignIntervalSec) : null
       };
 
       newSettings.linkToActive = isInstrumentEqual(initialSettings, newSettings);


### PR DESCRIPTION
Fixes #564 

# Description

fix auto align setting field

# Testing

add scalper orderbook widget
open settnigs
try type '0' to auto align field 

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
