### PR TITLE
fix stop-orders view in blotter

### DIFF
--- a/src/app/modules/blotter/components/stop-orders/stop-orders.component.html
+++ b/src/app/modules/blotter/components/stop-orders/stop-orders.component.html
@@ -74,9 +74,9 @@
           </td>
           <td [class]='ord.side.toString() === "sell" ? "sell" : "buy"' *ngIf='shouldShow("side")'>{{ ord.side }}</td>
           <td *ngIf='shouldShow("residue")'>{{ ord.residue }}</td>
-          <td *ngIf='shouldShow("volume")'>{{ ord.volume | number }}</td>
+          <td *ngIf='shouldShow("volume")'>{{ ord.type === 'stoplimit' ? (ord.volume | number) : '≈' + ord.triggerPrice * ord.qty * ord.qtyUnits }}</td>
           <td *ngIf='shouldShow("qty")'>{{ ord.qty | number }}</td>
-          <td *ngIf='shouldShow("price")'>{{ ord.price | number : '0.0-10'  }}</td>
+          <td *ngIf='shouldShow("price")'>{{ ord.type === 'stoplimit' ? (ord.price | number : '0.0-10') : '' }}</td>
           <td *ngIf='shouldShow("triggerPrice")'>{{ ord.triggerPrice | number }}</td>
           <td [class]='ord.status.toString() === "filled"
             ? (ord.status.toString() === "sell" ? "sell" : "buy") :


### PR DESCRIPTION
Fixes #624 

# Description

fix stop-orders view in blotter

# Testing

open blotter widget
go to stop-orders tab

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
