### PR TITLE
fix blotter info view while portfolio change

### DIFF
--- a/src/app/modules/blotter/widgets/blotter-widget/blotter-widget.component.spec.ts
+++ b/src/app/modules/blotter/widgets/blotter-widget/blotter-widget.component.spec.ts
@@ -1,32 +1,12 @@
-import {
-  ComponentFixture,
-  TestBed
-} from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BlotterSettings } from 'src/app/shared/models/settings/blotter-settings.model';
 
 import { BlotterWidgetComponent } from './blotter-widget.component';
 import { WidgetSettingsService } from "../../../../shared/services/widget-settings.service";
 import { of } from "rxjs";
-import {
-  getTranslocoModule,
-  mockComponent,
-  ngZorroMockComponents,
-  sharedModuleImportForTests
-} from "../../../../shared/utils/testing";
+import { getTranslocoModule, mockComponent, ngZorroMockComponents } from "../../../../shared/utils/testing";
 import { Store } from "@ngrx/store";
 import { EventEmitter } from '@angular/core';
-
-const settings: BlotterSettings = {
-  exchange: 'MOEX',
-  portfolio: 'D39004',
-  guid: '1230',
-  ordersColumns: ['ticker'],
-  stopOrdersColumns: ['ticker'],
-  tradesColumns: ['ticker'],
-  positionsColumns: ['ticker'],
-  activeTabIndex: 0,
-  isSoldPositionsHidden: false
-};
 
 describe('BlotterWidgetComponent', () => {
   let component: BlotterWidgetComponent;

--- a/src/app/shared/models/settings/blotter-settings.model.ts
+++ b/src/app/shared/models/settings/blotter-settings.model.ts
@@ -1,10 +1,12 @@
 import { WidgetSettings } from "../widget-settings.model";
 import { TableDisplaySettings } from './table-display-settings.model';
+import { MarketType } from "../portfolio-key.model";
 
 export interface BlotterSettings extends WidgetSettings {
   activeTabIndex: number,
   exchange: string,
   portfolio: string,
+  marketType: MarketType,
   ordersTable?: TableDisplaySettings,
   stopOrdersTable?: TableDisplaySettings,
   tradesTable?: TableDisplaySettings,

--- a/src/app/store/widget-settings/widget-settings-store.spec.ts
+++ b/src/app/store/widget-settings/widget-settings-store.spec.ts
@@ -1,17 +1,7 @@
 import { Store } from "@ngrx/store";
-import {
-  fakeAsync,
-  TestBed,
-  tick
-} from "@angular/core/testing";
-import {
-  generateRandomString,
-  sharedModuleImportForTests
-} from "../../shared/utils/testing";
-import {
-  of,
-  take
-} from "rxjs";
+import { fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { generateRandomString, sharedModuleImportForTests } from "../../shared/utils/testing";
+import { of, take } from "rxjs";
 import { LocalStorageService } from "../../shared/services/local-storage.service";
 import { EntityStatus } from "../../shared/models/enums/entity-status";
 import { selectWidgetSettingsState } from "./widget-settings.selectors";
@@ -27,7 +17,7 @@ import {
 } from "./widget-settings.actions";
 import { InstrumentKey } from "../../shared/models/instruments/instrument-key.model";
 import { InstrumentsService } from "../../modules/instruments/services/instruments.service";
-import { PortfolioKey } from "../../shared/models/portfolio-key.model";
+import { MarketType, PortfolioKey } from "../../shared/models/portfolio-key.model";
 import { selectNewPortfolio } from "../portfolios/portfolios.actions";
 import { selectNewInstrumentByBadge } from "../instruments/instruments.actions";
 
@@ -356,6 +346,7 @@ describe('Widget Settings Store', () => {
       const newPortfolioKey: PortfolioKey = {
         portfolio: 'G3214',
         exchange: Math.random() > 0.5 ? 'MOEX' : 'SPBX',
+        marketType: MarketType.Stock
       };
 
       localStorageServiceSpy.setItem.and.callFake((key: string, settings: [string, AnySettings][]) => {

--- a/src/app/store/widget-settings/widget-settings.reducer.ts
+++ b/src/app/store/widget-settings/widget-settings.reducer.ts
@@ -116,6 +116,7 @@ export const reducer = createReducer(
           ...state.entities[s],
           portfolio: newPortfolioKey.portfolio,
           exchange: newPortfolioKey.exchange,
+          marketType: newPortfolioKey.marketType
         }
       }));
 


### PR DESCRIPTION
Fixes #760 

# Description

fix blotter info view while portfolio change

# Testing

add two blotter widgets
turn off link to active in one of them
switch portfolio to forward market type
watch that info in not active blotter did not change

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
