### PR TITLE
fix column names in all-trades settings

### DIFF
--- a/src/app/modules/all-trades/components/all-trades-settings/all-trades-settings.component.html
+++ b/src/app/modules/all-trades/components/all-trades-settings/all-trades-settings.component.html
@@ -15,7 +15,7 @@
             <ng-container *transloco="let tTrades; scope: 'all-trades/all-trades'">
               <nz-option
                 *ngFor="let item of allTradesColumns"
-                [nzLabel]="tTrades('allTradesAllTrades.columns.' + item.columnId)"
+                [nzLabel]="tTrades('allTradesAllTrades.columns.' + item.columnId + '.displayName')"
                 [nzValue]="item.columnId"
               >
               </nz-option>


### PR DESCRIPTION
Fixes All trades widget settings columns view

# Description

fix column names in all-trades settings

# Testing

open all trades widget's settings
look at columns names in select

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
