### PR TITLE
add non-margin quantities to evaluation

### DIFF
--- a/src/app/modules/command/components/evaluation/evaluation.component.html
+++ b/src/app/modules/command/components/evaluation/evaluation.component.html
@@ -17,16 +17,36 @@
         [nzSpan]="2"
         [nzTitle]="quantityToBuyTitle"
       >
-        <div class="clickable" (click)="quantitySelect.emit(evaluation.quantityToBuy)">
-          {{evaluation.quantityToBuy}}
+        <div
+          class="clickable"
+          nz-tooltip
+          [nzTooltipTitle]="t('command.quantityToBuyTooltip')"
+        >
+          <span (click)="quantitySelect.emit(evaluation.quantityToBuy)">
+            {{evaluation.quantityToBuy}}
+          </span>
+          /
+          <span (click)="quantitySelect.emit(evaluation.notMarginQuantityToBuy)">
+            {{evaluation.notMarginQuantityToBuy}}
+          </span>
         </div>
       </nz-descriptions-item>
       <nz-descriptions-item
         [nzSpan]="2"
         [nzTitle]="quantityToSellTitle"
       >
-        <div class="clickable" (click)="quantitySelect.emit(evaluation.quantityToSell)">
-          {{evaluation.quantityToSell}}
+        <div
+          class="clickable"
+          nz-tooltip
+          [nzTooltipTitle]="t('command.quantityToSellTooltip')"
+        >
+          <span (click)="quantitySelect.emit(evaluation.quantityToSell)">
+            {{evaluation.quantityToSell}}
+          </span>
+          /
+          <span (click)="quantitySelect.emit(evaluation.notMarginQuantityToSell)">
+            {{evaluation.notMarginQuantityToSell}}
+          </span>
         </div>
       </nz-descriptions-item>
     </nz-descriptions>
@@ -42,7 +62,6 @@
         {{t('command.quantityToSell')}}
       </div>
     </ng-template>
-
   </ng-container>
 </ng-container>
 

--- a/src/app/shared/models/evaluation.model.ts
+++ b/src/app/shared/models/evaluation.model.ts
@@ -4,6 +4,8 @@ export interface Evaluation {
   exchange: string;
   quantityToSell: number;
   quantityToBuy: number;
+  notMarginQuantityToSell: number;
+  notMarginQuantityToBuy: number;
   orderEvaluation: number;
   commission: number;
 

--- a/src/assets/i18n/command/en.json
+++ b/src/assets/i18n/command/en.json
@@ -16,8 +16,8 @@
   "evaluationCommission": "Commission",
   "quantityToBuy": "For purchase",
   "quantityToSell": "For sale",
-  "quantityToBuyTooltip": "Margin buy /  buy on your own",
-  "quantityToSellTooltip": "Margin sell / sell on your own",
+  "quantityToBuyTooltip": "Margin buy /  Buy on your own",
+  "quantityToSellTooltip": "Margin sell / Sell on your own",
 
   "quantityLabel": "Lots quantity",
   "lot": "lot",

--- a/src/assets/i18n/command/en.json
+++ b/src/assets/i18n/command/en.json
@@ -16,6 +16,8 @@
   "evaluationCommission": "Commission",
   "quantityToBuy": "For purchase",
   "quantityToSell": "For sale",
+  "quantityToBuyTooltip": "Margin buy /  buy on your own",
+  "quantityToSellTooltip": "Margin sell / sell on your own",
 
   "quantityLabel": "Lots quantity",
   "lot": "lot",

--- a/src/assets/i18n/command/ru.json
+++ b/src/assets/i18n/command/ru.json
@@ -16,6 +16,8 @@
   "evaluationCommission": "Комиссия",
   "quantityToBuy": "К покупке",
   "quantityToSell": "К продаже",
+  "quantityToBuyTooltip": "Маржинальная покупка / покупка на свои",
+  "quantityToSellTooltip": "Маржинальная продажа / продажа на свои",
 
   "quantityLabel": "Кол-во лотов",
   "lot": "лот",

--- a/src/assets/i18n/command/ru.json
+++ b/src/assets/i18n/command/ru.json
@@ -16,8 +16,8 @@
   "evaluationCommission": "Комиссия",
   "quantityToBuy": "К покупке",
   "quantityToSell": "К продаже",
-  "quantityToBuyTooltip": "Маржинальная покупка / покупка на свои",
-  "quantityToSellTooltip": "Маржинальная продажа / продажа на свои",
+  "quantityToBuyTooltip": "Маржинальная покупка / Покупка на свои",
+  "quantityToSellTooltip": "Маржинальная продажа / Продажа на свои",
 
   "quantityLabel": "Кол-во лотов",
   "lot": "лот",


### PR DESCRIPTION
Fixes #614 

# Description

add non-margin quantities to evaluation in buy/sell columns

# Testing

open order-submit widget/modal
look in evaluation

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
