### PR TITLE
Issue #1131: Added reverse and close position buttons to blotter

### DIFF
--- a/src/app/modules/blotter/components/positions/positions.component.html
+++ b/src/app/modules/blotter/components/positions/positions.component.html
@@ -22,6 +22,7 @@
                 nzTableLayout="fixed">
         <thead>
         <tr (cdkDropListDropped)="changeColumnOrder($event)" cdkDropList cdkDropListOrientation="horizontal">
+          <th nzWidth="45px"></th>
           <th (atsWidthChanged)="saveColumnWidth(column.id, $event)"
               (atsWidthChanging)="recalculateTableWidth($event)"
               *ngFor='let column of listOfColumns'
@@ -57,6 +58,30 @@
         <tbody>
         <ng-template let-pos nz-virtual-scroll>
           <tr (click)="selectInstrument(pos.symbol, pos.exchange)">
+            <td>
+              <a *ngIf="abs(pos.qtyTFutureBatch) > 0"
+                 (click)="$event.preventDefault(); $event.stopPropagation()"
+                 nz-popconfirm
+                 [nzCancelText]="t('no')"
+                 [nzOkText]="t('yes')"
+                 [nzPopconfirmTitle]="t('blotterPositions.confirmReverse')"
+                 (nzOnConfirm)="reversePosition(pos)"
+              >
+                <i nz-icon nzTheme="outline" nzType="retweet"></i>
+              </a>
+              &nbsp;
+              <a
+                *ngIf="abs(pos.qtyTFutureBatch) > 0"
+                (click)="$event.preventDefault(); $event.stopPropagation()"
+                nz-popconfirm
+                [nzCancelText]="t('no')"
+                [nzOkText]="t('yes')"
+                [nzPopconfirmTitle]="t('blotterPositions.confirmClose')"
+                (nzOnConfirm)="closePosition(pos)"
+              >
+                <i nz-icon nzTheme="outline" nzType="close-circle"></i>
+              </a>
+            </td>
             <ng-container *ngFor='let column of listOfColumns'>
               <td *ngIf='column.id === "symbol"' class='bold'>
                 <span class="symbol-name">{{ pos.symbol }}</span>

--- a/src/app/modules/blotter/components/positions/positions.component.spec.ts
+++ b/src/app/modules/blotter/components/positions/positions.component.spec.ts
@@ -10,6 +10,7 @@ import {
   mockComponent,
   sharedModuleImportForTests
 } from "../../../../shared/utils/testing";
+import { OrderService } from "../../../../shared/services/orders/order.service";
 
 describe('PositionsComponent', () => {
   let component: PositionsComponent;
@@ -36,6 +37,12 @@ describe('PositionsComponent', () => {
           useValue: { getSettings: jasmine.createSpy('getSettings').and.returnValue(of(settingsMock)) }
         },
         { provide: BlotterService, useClass: MockServiceBlotter },
+        {
+          provide: OrderService,
+          useValue: {
+            submitMarketOrder: jasmine.createSpy('submitMarketOrder').and.callThrough()
+          }
+        },
         ...commonTestProviders
       ],
       declarations: [

--- a/src/app/modules/blotter/components/positions/positions.component.ts
+++ b/src/app/modules/blotter/components/positions/positions.component.ts
@@ -37,6 +37,8 @@ import { BaseColumnSettings } from "../../../../shared/models/settings/table-set
 import { NzTableFilterList } from "ng-zorro-antd/table/src/table.types";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { BaseTableComponent } from "../base-table/base-table.component";
+import { OrderService } from "../../../../shared/services/orders/order.service";
+import { CommonOrderCommands } from "../../../../shared/utils/common-order-commands";
 
 interface PositionDisplay extends Position {
   id: string;
@@ -164,10 +166,12 @@ export class PositionsComponent
   fileSuffix = 'positions';
   badgeColor = defaultBadgeColor;
 
+  readonly abs = Math.abs;
   constructor(
     protected readonly service: BlotterService,
     protected readonly settingsService: WidgetSettingsService,
     protected readonly translatorService: TranslatorService,
+    protected readonly ordersService: OrderService,
     protected readonly destroyRef: DestroyRef
   ) {
     super(service, settingsService, translatorService, destroyRef);
@@ -242,5 +246,13 @@ export class PositionsComponent
     return price > 10
       ? MathHelper.round(price, 2)
       : MathHelper.round(price, 6);
+  }
+
+  closePosition(position: PositionDisplay) {
+    CommonOrderCommands.closePositionByMarket(position, undefined, this.ordersService);
+  }
+
+  reversePosition(position: PositionDisplay) {
+    CommonOrderCommands.reversePositionsByMarket(position, undefined, this.ordersService);
   }
 }

--- a/src/app/modules/scalper-order-book/services/scalper-command-processor.service.ts
+++ b/src/app/modules/scalper-order-book/services/scalper-command-processor.service.ts
@@ -204,15 +204,10 @@ export class ScalperCommandProcessorService {
       this.callWithSettings(
         dataContext,
         settings => {
-          this.callWithPortfolioKey(
+          this.callWithPosition(
             dataContext,
-            portfolioKey => {
-              this.callWithPosition(
-                dataContext,
-                position => {
-                  this.scalperOrdersService.reversePositionsByMarket(position, settings.widgetSettings.instrumentGroup, portfolioKey);
-                }
-              );
+            position => {
+              this.scalperOrdersService.reversePositionsByMarket(position, settings.widgetSettings.instrumentGroup);
             }
           );
         }
@@ -238,14 +233,9 @@ export class ScalperCommandProcessorService {
     this.callWithSettings(
       dataContext,
       settings => {
-        this.callWithPortfolioKey(
+        this.callWithPosition(
           dataContext,
-          portfolioKey => {
-            this.callWithPosition(
-              dataContext,
-              position => this.scalperOrdersService.closePositionsByMarket(position, settings.widgetSettings.instrumentGroup, portfolioKey)
-            );
-          }
+          position => this.scalperOrdersService.closePositionsByMarket(position, settings.widgetSettings.instrumentGroup)
         );
       }
     );

--- a/src/app/modules/scalper-order-book/services/scalper-orders.service.spec.ts
+++ b/src/app/modules/scalper-order-book/services/scalper-orders.service.spec.ts
@@ -153,6 +153,7 @@ describe('ScalperOrdersService', () => {
       const position1 = {
         symbol: testInstrumentKey1.symbol,
         exchange: testInstrumentKey1.exchange,
+        portfolio: portfolioKey.portfolio,
         qtyTFuture: getRandomInt(1, 100),
         qtyTFutureBatch: getRandomInt(1, 10)
       } as Position;
@@ -160,13 +161,14 @@ describe('ScalperOrdersService', () => {
       const position2 = {
         symbol: testInstrumentKey2.symbol,
         exchange: testInstrumentKey1.exchange,
+        portfolio: portfolioKey.portfolio,
         qtyTFuture: getRandomInt(1, 100) * -1,
         qtyTFutureBatch: getRandomInt(1, 10) * -1
       } as Position;
 
       orderServiceSpy.submitMarketOrder.and.returnValue(of({}));
 
-      service.closePositionsByMarket(position1, testInstrumentKey1.instrumentGroup, portfolioKey);
+      service.closePositionsByMarket(position1, testInstrumentKey1.instrumentGroup);
       tick(10000);
 
       expect(orderServiceSpy.submitMarketOrder).toHaveBeenCalledOnceWith(
@@ -179,7 +181,7 @@ describe('ScalperOrdersService', () => {
       );
 
       orderServiceSpy.submitMarketOrder.calls.reset();
-      service.closePositionsByMarket(position2, testInstrumentKey2.instrumentGroup, portfolioKey);
+      service.closePositionsByMarket(position2, testInstrumentKey2.instrumentGroup);
       tick(10000);
 
       expect(orderServiceSpy.submitMarketOrder).toHaveBeenCalledOnceWith(
@@ -995,12 +997,13 @@ describe('ScalperOrdersService', () => {
         symbol: testInstrumentKey.symbol,
         exchange: testInstrumentKey.exchange,
         qtyTFuture: getRandomInt(1, 100),
-        qtyTFutureBatch: getRandomInt(1, 10)
+        qtyTFutureBatch: getRandomInt(1, 10),
+        portfolio: portfolioKey.portfolio
       } as Position;
 
       orderServiceSpy.submitMarketOrder.and.returnValue(of({}));
 
-      service.reversePositionsByMarket(position, testInstrumentKey.instrumentGroup, portfolioKey);
+      service.reversePositionsByMarket(position, testInstrumentKey.instrumentGroup);
 
       tick(10000);
       expect(orderServiceSpy.submitMarketOrder)
@@ -1017,7 +1020,7 @@ describe('ScalperOrdersService', () => {
       orderServiceSpy.submitMarketOrder.calls.reset();
       position.qtyTFutureBatch = position.qtyTFutureBatch * -1;
 
-      service.reversePositionsByMarket(position, testInstrumentKey.instrumentGroup, portfolioKey);
+      service.reversePositionsByMarket(position, testInstrumentKey.instrumentGroup);
       tick(10000);
       expect(orderServiceSpy.submitMarketOrder)
         .withContext('qtyTFutureBatch < 0')

--- a/src/app/modules/scalper-order-book/services/scalper-orders.service.ts
+++ b/src/app/modules/scalper-order-book/services/scalper-orders.service.ts
@@ -24,6 +24,7 @@ import {
   NewStopLimitOrder,
   NewStopMarketOrder
 } from "../../../shared/models/orders/new-order.model";
+import { CommonOrderCommands } from "../../../shared/utils/common-order-commands";
 
 enum BracketOrderType {
   Top = 'top',
@@ -58,22 +59,16 @@ export class ScalperOrdersService {
     }
   }
 
-  closePositionsByMarket(position: Position | null, instrumentGroup: string | undefined, portfolio: PortfolioKey): void {
+  closePositionsByMarket(position: Position | null, instrumentGroup: string | undefined): void {
     if (!position || !position.qtyTFutureBatch) {
       return;
     }
 
-    this.orderService.submitMarketOrder({
-        side: position.qtyTFutureBatch > 0 ? Side.Sell : Side.Buy,
-        quantity: Math.abs(position.qtyTFutureBatch),
-        instrument: {
-          symbol: position.symbol,
-          exchange: position.exchange,
-          instrumentGroup: instrumentGroup
-        },
-      },
-      portfolio.portfolio
-    ).subscribe();
+    CommonOrderCommands.closePositionByMarket(
+      position,
+      instrumentGroup,
+      this.orderService
+    );
   }
 
   placeBestOrder(
@@ -303,22 +298,12 @@ export class ScalperOrdersService {
     }
   }
 
-  reversePositionsByMarket(position: Position | null, instrumentGroup: string | undefined, portfolio: PortfolioKey): void {
+  reversePositionsByMarket(position: Position | null, instrumentGroup: string | undefined): void {
     if (!position || !position.qtyTFutureBatch) {
       return;
     }
 
-    this.orderService.submitMarketOrder({
-        side: position.qtyTFutureBatch > 0 ? Side.Sell : Side.Buy,
-        quantity: Math.abs(position.qtyTFutureBatch * 2),
-        instrument: {
-          symbol: position.symbol,
-          exchange: position.exchange,
-          instrumentGroup: instrumentGroup
-        },
-      },
-      portfolio.portfolio
-    ).subscribe();
+    CommonOrderCommands.reversePositionsByMarket(position, instrumentGroup, this.orderService);
   }
 
   setStopLimit(

--- a/src/app/shared/utils/common-order-commands.ts
+++ b/src/app/shared/utils/common-order-commands.ts
@@ -1,0 +1,49 @@
+﻿import { Position } from "../models/positions/position.model";
+import { OrderService } from "../services/orders/order.service";
+import { Side } from "../models/enums/side.model";
+
+export class CommonOrderCommands {
+  static closePositionByMarket(
+    position: Position,
+    instrumentGroup: string | undefined,
+    orderService: OrderService
+  ): void {
+    if (!position.qtyTFutureBatch) {
+      return;
+    }
+
+    orderService.submitMarketOrder({
+        side: position.qtyTFutureBatch > 0 ? Side.Sell : Side.Buy,
+        quantity: Math.abs(position.qtyTFutureBatch),
+        instrument: {
+          symbol: position.symbol,
+          exchange: position.exchange,
+          instrumentGroup: instrumentGroup
+        },
+      },
+      position.portfolio
+    ).subscribe();
+  }
+
+  static reversePositionsByMarket(
+    position: Position,
+    instrumentGroup: string | undefined,
+    orderService: OrderService
+  ): void {
+    if (!position.qtyTFutureBatch) {
+      return;
+    }
+
+    orderService.submitMarketOrder({
+        side: position.qtyTFutureBatch > 0 ? Side.Sell : Side.Buy,
+        quantity: Math.abs(position.qtyTFutureBatch * 2),
+        instrument: {
+          symbol: position.symbol,
+          exchange: position.exchange,
+          instrumentGroup: instrumentGroup
+        },
+      },
+      position.portfolio
+    ).subscribe();
+  }
+}

--- a/src/assets/i18n/blotter/positions/en.json
+++ b/src/assets/i18n/blotter/positions/en.json
@@ -48,5 +48,8 @@
     }
   },
   "emptyPositions": "There are no positions",
-  "emptyPositionsWithFilters": "Nothing found with these filters"
+  "emptyPositionsWithFilters": "Nothing found with these filters",
+
+  "confirmClose": "Do you want to CLOSE the position?",
+  "confirmReverse": "Do you want to REVERSE the position?"
 }

--- a/src/assets/i18n/blotter/positions/ru.json
+++ b/src/assets/i18n/blotter/positions/ru.json
@@ -48,5 +48,8 @@
     }
   },
   "emptyPositions": "Позиций нет",
-  "emptyPositionsWithFilters": "С такими фильтрами ничего не найдено"
+  "emptyPositionsWithFilters": "С такими фильтрами ничего не найдено",
+
+  "confirmClose": "Закрыть позицию?",
+  "confirmReverse": "Перевернуть позицию?"
 }


### PR DESCRIPTION
Fixes #1131

# Description

Added reverse and close position buttons to blotter

# Testing

Open "Positions" tab of blotter widget. Check first column

# Risk

No major changes

# Do you agree with those?
- [x] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [x] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
