### PR TITLE
#1227 fix residue column in blotter stop orders

### DIFF
--- a/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
+++ b/src/app/modules/blotter/components/stop-orders/stop-orders.component.ts
@@ -312,7 +312,7 @@ export class StopOrdersComponent extends BaseTableComponent<DisplayOrder, OrderF
       map(([orders, f, converter, groups]) => orders
         .map(o => ({
           ...o,
-          residue: `0/${o.qty}`,
+          residue: `${o.filled ?? 0}/${o.qty}`,
           volume: MathHelper.round(o.qtyUnits * o.price, 2),
           transTime: converter.toTerminalDate(o.transTime),
           endTime: !!o.endTime ? converter.toTerminalDate(o.endTime) : o.endTime,


### PR DESCRIPTION
Fixes #1227 

# Description

 residue column in blotter stop orders

# Testing

open blotter widget
open stop-orders tab
look at residue column data

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
