### PR TITLE
#1152 add seconds timeframes in light and tech charts

### DIFF
--- a/src/app/modules/light-chart/models/light-chart.models.ts
+++ b/src/app/modules/light-chart/models/light-chart.models.ts
@@ -4,6 +4,9 @@ import { LightChartDatafeed } from '../services/light-chart-datafeed';
 import { ThemeColors } from '../../../shared/models/settings/theme-settings.model';
 
 export enum TimeframeValue {
+  S1 = '1',
+  S5 = '5',
+  S10 = '10',
   M1 = '60',
   M5 = '300',
   M15 = '900',

--- a/src/app/modules/light-chart/services/light-chart-datafeed.ts
+++ b/src/app/modules/light-chart/services/light-chart-datafeed.ts
@@ -117,6 +117,12 @@ export class LightChartDatafeed {
         return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes() - 5))).getTime() / 1000;
       case TimeframeValue.M1:
         return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes() - 1))).getTime() / 1000;
+      case TimeframeValue.S10:
+        return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds() - 10))).getTime() / 1000;
+      case TimeframeValue.S5:
+        return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds() - 5))).getTime() / 1000;
+      case TimeframeValue.S1:
+        return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds() - 1))).getTime() / 1000;
       default:
         return now.getTime() / 1000;
     }

--- a/src/app/modules/light-chart/utils/light-chart-wrapper.ts
+++ b/src/app/modules/light-chart/utils/light-chart-wrapper.ts
@@ -309,6 +309,11 @@ export class LightChartWrapper {
       case TimeframeValue.M5:
       case TimeframeValue.M1:
         return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 3))).getTime();
+      case TimeframeValue.S10:
+        return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes() - 20))).getTime();
+      case TimeframeValue.S5:
+      case TimeframeValue.S1:
+        return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours(), now.getUTCMinutes() - 5))).getTime();
       default:
         return (new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1))).getTime();
     }
@@ -329,6 +334,12 @@ export class LightChartWrapper {
       case TimeframeValue.M5:
       case TimeframeValue.M1:
         return (new Date(Date.UTC(fromDate.getUTCFullYear(), fromDate.getUTCMonth(), fromDate.getUTCDate() - 3))).getTime();
+      case TimeframeValue.S10:
+        return (new Date(Date.UTC(fromDate.getUTCFullYear(), fromDate.getUTCMonth(), fromDate.getUTCDate(), fromDate.getUTCHours(), fromDate.getUTCMinutes() - 20))).getTime();
+      case TimeframeValue.S5:
+      case TimeframeValue.S1:
+        return (new Date(Date.UTC(fromDate.getUTCFullYear(), fromDate.getUTCMonth(), fromDate.getUTCDate(), fromDate.getUTCHours(), fromDate.getUTCMinutes() - 5))).getTime();
+
       default:
         return (new Date(Date.UTC(fromDate.getUTCFullYear(), fromDate.getUTCMonth() - 1))).getTime();
     }

--- a/src/app/modules/light-chart/utils/timeframes-helper.ts
+++ b/src/app/modules/light-chart/utils/timeframes-helper.ts
@@ -9,6 +9,9 @@ export interface Timeframe {
 
 export class TimeframesHelper {
   public static timeFrames: Timeframe[] = [
+    { label: '1s', value: TimeframeValue.S1 },
+    { label: '5s', value: TimeframeValue.S5 },
+    { label: '10s', value: TimeframeValue.S10 },
     { label: '1m', value: TimeframeValue.M1 },
     { label: '5m', value: TimeframeValue.M5 },
     { label: '15m', value: TimeframeValue.M15 },
@@ -60,6 +63,21 @@ export class TimeframesHelper {
           [...existing, ...history],
           (b1, b2) => b1.time - b2.time,
           (b1, b2) => b1.time - b2.time < 60);
+      case TimeframeValue.S10:
+        return findUniqueElements(
+          [...existing, ...history],
+          (b1, b2) => b1.time - b2.time,
+          (b1, b2) => b1.time - b2.time < 10);
+      case TimeframeValue.S5:
+        return findUniqueElements(
+          [...existing, ...history],
+          (b1, b2) => b1.time - b2.time,
+          (b1, b2) => b1.time - b2.time < 5);
+      case TimeframeValue.S1:
+        return findUniqueElements(
+          [...existing, ...history],
+          (b1, b2) => b1.time - b2.time,
+          (b1, b2) => b1.time - b2.time < 1);
       default:
         return existing;
     }

--- a/src/app/modules/tech-chart/components/tech-chart/tech-chart.component.ts
+++ b/src/app/modules/tech-chart/components/tech-chart/tech-chart.component.ts
@@ -25,6 +25,7 @@ import {
   PlusClickParams,
   ResolutionString,
   SubscribeEventsMap,
+  TimeFrameType,
   widget
 } from '../../../../../assets/charting_library';
 import {WidgetSettingsService} from '../../../../shared/services/widget-settings.service';
@@ -58,6 +59,7 @@ import {EditOrderDialogParams, OrderType} from "../../../../shared/models/orders
 import { WidgetsSharedDataService } from "../../../../shared/services/widgets-shared-data.service";
 import { Trade } from "../../../../shared/models/trades/trade.model";
 import { TradesHistoryService } from "../../../../shared/services/trades-history.service";
+import { addSeconds } from "../../../../shared/utils/datetime";
 
 type ExtendedSettings = { widgetSettings: TechChartSettings, instrument: Instrument };
 
@@ -397,7 +399,7 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
         { text: '1m', resolution: '1H' as ResolutionString, description: this.translateFn(['timeframes', '1m', 'desc']), title: this.translateFn(['timeframes', '1m', 'title']) },
         { text: '14d', resolution: '1H' as ResolutionString, description: this.translateFn(['timeframes', '2w', 'desc']), title: this.translateFn(['timeframes', '2w', 'title']) },
         { text: '7d', resolution: '15' as ResolutionString, description: this.translateFn(['timeframes', '1w', 'desc']), title: this.translateFn(['timeframes', '1w', 'title']) },
-        { text: '1d', resolution: '5' as ResolutionString as ResolutionString, description: this.translateFn(['timeframes', '1d', 'desc']), title: this.translateFn(['timeframes', '1d', 'title']) },
+        { text: '1d', resolution: '5' as ResolutionString, description: this.translateFn(['timeframes', '1d', 'desc']), title: this.translateFn(['timeframes', '1d', 'title']) },
       ],
       symbol_search_request_delay: 2000,
       //features
@@ -413,6 +415,7 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
         'side_toolbar_in_fullscreen_mode',
         'chart_crosshair_menu',
         'show_spread_operators',
+        'seconds_resolution'
       ] as unknown as ChartingLibraryFeatureset[]
     };
 
@@ -443,6 +446,17 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
         filter(needUnlink => !!needUnlink)
       )
         .subscribe(() => this.settingsService.updateIsLinked(this.guid, false));
+
+      this.chartState?.widget!.activeChart().onIntervalChanged()
+        .subscribe(null, (interval, timeframeObj) => {
+          if (interval.includes('S')) {
+            timeframeObj.timeframe = {
+              from: Math.round(addSeconds(new Date(), +interval.slice(0, -1) * 30).getTime() / 1000),
+              to: Math.round(new Date().getTime() / 1000),
+              type: TimeFrameType.TimeRange
+            };
+          }
+        });
     });
   }
 

--- a/src/app/modules/tech-chart/components/tech-chart/tech-chart.component.ts
+++ b/src/app/modules/tech-chart/components/tech-chart/tech-chart.component.ts
@@ -204,6 +204,7 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
   private lastLang?: string;
   private lastTimezone?: TimezoneDisplayOption;
   private translateFn!: (key: string[], params?: HashMap) => string;
+  private intervalChangeSub?: Subscription;
 
   constructor(
     private readonly settingsService: WidgetSettingsService,
@@ -233,6 +234,7 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
       this.chartState.ordersState?.destroy();
       this.chartState.positionState?.destroy();
       this.chartState.tradesState?.destroy();
+      this.intervalChangeSub?.unsubscribe();
       this.chartState.widget.remove();
     }
 
@@ -346,6 +348,7 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
     if (this.chartState) {
       if (forceRecreate) {
         this.chartState.widget?.remove();
+        this.intervalChangeSub?.unsubscribe();
       }
       else {
         this.chartState.widget.activeChart().setSymbol(
@@ -448,12 +451,12 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
       )
         .subscribe(() => this.settingsService.updateIsLinked(this.guid, false));
 
-      const tearDown = new Subscription();
+      this.intervalChangeSub = new Subscription();
 
-      this.chartState?.widget!.activeChart().onIntervalChanged()
+      this.chartState!.widget.activeChart().onIntervalChanged()
         .subscribe(null, this.intervalChangeCallback);
 
-      tearDown.add(() => this.chartState?.widget!.activeChart().onIntervalChanged().unsubscribe(null, this.intervalChangeCallback));
+      this.intervalChangeSub.add(() => this.chartState?.widget!.activeChart().onIntervalChanged().unsubscribe(null, this.intervalChangeCallback));
     });
   }
 

--- a/src/app/modules/tech-chart/services/tech-chart-datafeed.service.spec.ts
+++ b/src/app/modules/tech-chart/services/tech-chart-datafeed.service.spec.ts
@@ -91,6 +91,9 @@ describe('TechChartDatafeedService', () => {
       const expectedConfig: DatafeedConfiguration = {
         supports_time: true,
         supported_resolutions: [
+          '1S' as ResolutionString,
+          '5S' as ResolutionString,
+          '10S' as ResolutionString,
           '1' as ResolutionString,
           '5' as ResolutionString,
           '15' as ResolutionString,
@@ -162,9 +165,13 @@ describe('TechChartDatafeedService', () => {
       format: 'price',
       has_empty_bars: false,
       has_intraday: true,
+      has_seconds: true,
       timezone: 'Europe/Moscow',
       session: '24x7',
       supported_resolutions: [
+        '1S' as ResolutionString,
+        '5S' as ResolutionString,
+        '10S' as ResolutionString,
         '1' as ResolutionString,
         '5' as ResolutionString,
         '15' as ResolutionString,

--- a/src/app/modules/tech-chart/services/tech-chart-datafeed.service.ts
+++ b/src/app/modules/tech-chart/services/tech-chart-datafeed.service.ts
@@ -155,6 +155,7 @@ export class TechChartDatafeedService implements IBasicDataFeed {
         type: instrumentDetails.type ?? '',
         has_empty_bars: false,
         has_intraday: true,
+        has_seconds: true,
         timezone: 'Europe/Moscow',
         supported_resolutions: this.getSupportedResolutions(),
         session: '24x7'
@@ -435,6 +436,9 @@ export class TechChartDatafeedService implements IBasicDataFeed {
 
   private getSupportedResolutions(): ResolutionString[] {
     return [
+      '1S' as ResolutionString,
+      '5S' as ResolutionString,
+      '10S' as ResolutionString,
       '1' as ResolutionString,
       '5' as ResolutionString,
       '15' as ResolutionString,


### PR DESCRIPTION
Fixes #1152 

# Description

add seconds timeframes in light and tech charts

# Testing

open light chart or tech chart
select seconds timeframe

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
