### PR TITLE
#1208 add new colored badges

### DIFF
--- a/src/app/shared/components/instrument-badge-display/instrument-badge-display.component.ts
+++ b/src/app/shared/components/instrument-badge-display/instrument-badge-display.component.ts
@@ -3,7 +3,7 @@ import {InstrumentKey} from "../../models/instruments/instrument-key.model";
 import {combineLatest, Observable, shareReplay} from "rxjs";
 import {InstrumentGroups} from "../../models/dashboard/dashboard.model";
 import {map} from "rxjs/operators";
-import {defaultBadgeColor} from "../../utils/instruments";
+import { defaultBadgeColor, instrumentsBadges } from "../../utils/instruments";
 import {DashboardContextService} from "../../services/dashboard-context.service";
 import {TerminalSettingsService} from "../../services/terminal-settings.service";
 
@@ -43,6 +43,7 @@ export class InstrumentBadgeDisplayComponent implements OnInit {
 
   getApplicableBadges(selectedGroups: InstrumentGroups): string[] {
     return Object.entries(selectedGroups)
+      .filter(([key]) => instrumentsBadges.includes(key))
       .filter(([, value]) => this.isBadgeApplicable(value))
       .map(([key]) => key);
   }

--- a/src/app/shared/components/merged-badge/merged-badge.component.ts
+++ b/src/app/shared/components/merged-badge/merged-badge.component.ts
@@ -12,14 +12,14 @@ export class MergedBadgeComponent {
   width: number = 10;
 
   private readonly colorOverrides = new Map<string, string>([
-    ["yellow", "#fadb14"],
-    ["blue", "#1890ff"],
-    ["pink", "#eb2f96"],
-    ["red", "#f5222d"],
-    ["orange", "#fa8c16"],
-    ['green', '#49aa1b'],
-    ['cyan', '#13a9aa'],
-    ['geekblue', '#2b4bcd']
+    ["#FFFF00", "#FFFF00"],
+    ["#FF0000", "#FF0000"],
+    ["#FFA500", "#FFA500"],
+    ["#008C00", "#008C00"],
+    ["#00C4FF", "#00C4FF"],
+    ['#0000FF', '#0000FF'],
+    ['#F100F1', '#F100F1'],
+    ['#800000', '#800000']
   ]);
 
   getBackgroundStyle(): string {

--- a/src/app/shared/components/merged-badge/merged-badge.component.ts
+++ b/src/app/shared/components/merged-badge/merged-badge.component.ts
@@ -17,6 +17,9 @@ export class MergedBadgeComponent {
     ["pink", "#eb2f96"],
     ["red", "#f5222d"],
     ["orange", "#fa8c16"],
+    ['green', '#49aa1b'],
+    ['cyan', '#13a9aa'],
+    ['geekblue', '#2b4bcd']
   ]);
 
   getBackgroundStyle(): string {

--- a/src/app/shared/utils/instruments.ts
+++ b/src/app/shared/utils/instruments.ts
@@ -10,7 +10,10 @@ export const instrumentsBadges = [
   'blue',
   'pink',
   'red',
-  'orange'
+  'orange',
+  'green',
+  'cyan',
+  'geekblue'
 ];
 
 /**

--- a/src/app/shared/utils/instruments.ts
+++ b/src/app/shared/utils/instruments.ts
@@ -6,20 +6,20 @@ import { Instrument } from '../models/instruments/instrument.model';
  * badge colors array
  */
 export const instrumentsBadges = [
-  'yellow',
-  'blue',
-  'pink',
-  'red',
-  'orange',
-  'green',
-  'cyan',
-  'geekblue'
+  '#FFFF00',
+  '#FF0000',
+  '#FFA500',
+  '#008C00',
+  '#00C4FF',
+  '#0000FF',
+  '#F100F1',
+  '#800000',
 ];
 
 /**
  * default badge color
  */
-export const defaultBadgeColor = 'yellow';
+export const defaultBadgeColor = '#FFFF00';
 
 /**
  * Determines the category of instrument by CFI code

--- a/src/app/store/dashboards/dashboards.effects.ts
+++ b/src/app/store/dashboards/dashboards.effects.ts
@@ -153,7 +153,7 @@ export class DashboardsEffects {
   setDefaultInstrumentsSelectionForCurrentDashboard$ = createEffect(() => {
     return DashboardsStreams.getSelectedDashboard(this.store).pipe(
       filter((d): d is Dashboard => !!d),
-      filter(d => !d.instrumentsSelection),
+      filter(d => instrumentsBadges.some(badge => !d.instrumentsSelection?.[badge])),
       distinctUntilChanged((previous, current) => previous.guid === current.guid),
       mapWith(
         () => this.marketService.getAllExchanges().pipe(take(1)),
@@ -173,7 +173,7 @@ export class DashboardsEffects {
               dashboardGuid: dashboard.guid,
               selection: instrumentsBadges.map(badge => ({
                 groupKey: badge,
-                instrumentKey: {
+                instrumentKey: dashboard.instrumentsSelection?.[badge] ?? {
                   ...exchangeSettings!.settings.defaultInstrument,
                   exchange: exchangeSettings!.exchange
                 }

--- a/src/app/store/widget-settings/widget-settings-store.spec.ts
+++ b/src/app/store/widget-settings/widget-settings-store.spec.ts
@@ -22,6 +22,7 @@ import {
 } from "./widget-settings.actions";
 import { InstrumentsService } from "../../modules/instruments/services/instruments.service";
 import { WidgetSettings } from '../../shared/models/widget-settings.model';
+import { defaultBadgeColor } from "../../shared/utils/instruments";
 
 describe('Widget Settings Store', () => {
   let store: Store;
@@ -38,7 +39,8 @@ describe('Widget Settings Store', () => {
         guid: GuidGenerator.newGuid(),
         exchange: Math.random() > 0.5 ? 'MOEX' : 'SPBX',
         width: Math.round(Math.random() * 100),
-        height: Math.round(Math.random() * 100)
+        height: Math.round(Math.random() * 100),
+        badgeColor: defaultBadgeColor
       });
     }
 

--- a/src/app/store/widget-settings/widget-settings.effects.ts
+++ b/src/app/store/widget-settings/widget-settings.effects.ts
@@ -1,9 +1,10 @@
-import {Injectable} from '@angular/core';
-import {Actions, concatLatestFrom, createEffect, ofType} from '@ngrx/effects';
-import {map} from "rxjs/operators";
+import { Injectable } from '@angular/core';
+import { Actions, concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
+import { filter, map } from "rxjs/operators";
 import * as WidgetSettingsActions from './widget-settings.actions';
-import {WidgetSettingsStreams} from "./widget-settings.streams";
-import {Store} from "@ngrx/store";
+import { WidgetSettingsStreams } from "./widget-settings.streams";
+import { Store } from "@ngrx/store";
+import { instrumentsBadges } from "../../shared/utils/instruments";
 
 @Injectable()
 export class WidgetSettingsEffects {
@@ -20,6 +21,17 @@ export class WidgetSettingsEffects {
       ),
       concatLatestFrom(() => WidgetSettingsStreams.getAllSettings(this.store)),
       map(([, settings]) => WidgetSettingsActions.settingsUpdated({settings}))
+    );
+  });
+
+  setBadgesColors$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(
+        WidgetSettingsActions.initWidgetSettings
+      ),
+      map(a => a.settings.filter(s => !instrumentsBadges.includes(s.badgeColor ?? ''))),
+      filter(settings => !!settings.length),
+      map(settings => WidgetSettingsActions.setDefaultBadges({ settingGuids: settings.map(s => s.guid) }))
     );
   });
 


### PR DESCRIPTION
Fixes #1208 

# Description

add new colored badges

# Testing

turn on colored badges in terminal settings
open badges dropdown on widgets

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
