### PR TITLE
#1254 add time in trade tooltip in tech chart

### DIFF
--- a/src/assets/i18n/tech-chart/tech-chart/en.json
+++ b/src/assets/i18n/tech-chart/tech-chart/en.json
@@ -15,6 +15,7 @@
   "priceLabel": "Price",
   "qtyLabel": "Qty",
   "sideLabel": "Side",
+  "timeLabel": "Time",
 
   "timeframes": {
     "all": {

--- a/src/assets/i18n/tech-chart/tech-chart/ru.json
+++ b/src/assets/i18n/tech-chart/tech-chart/ru.json
@@ -15,6 +15,7 @@
   "priceLabel": "Цена",
   "qtyLabel": "Кол-во",
   "sideLabel": "Сторона",
+  "timeLabel": "Время",
 
   "timeframes": {
     "all": {


### PR DESCRIPTION
Fixes #1254 

# Description

add time in trade tooltip in tech chart

# Testing

open tech chart widget
turn on 'show trades' in settings
switch timezone
look in trade tooltip

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
