### PR TITLE
#1695 add hide-tooltip setting in scalper orderbook

### DIFF
--- a/src/app/modules/scalper-order-book/components/bottom-floating-panel/bottom-floating-panel.component.html
+++ b/src/app/modules/scalper-order-book/components/bottom-floating-panel/bottom-floating-panel.component.html
@@ -4,7 +4,11 @@
       <ats-modifiers-indicator></ats-modifiers-indicator>
     </div>
     <div class="d-flex" *ngIf="showShortLongIndicators(extendedSettings.widgetSettings)">
-      <ats-short-long-indicator [dataContext]="dataContext" orientation="vertical"></ats-short-long-indicator>
+      <ats-short-long-indicator
+        [dataContext]="dataContext"
+        [hideTooltips]="extendedSettings.widgetSettings.hideTooltips ?? false"
+        orientation="vertical"
+      ></ats-short-long-indicator>
     </div>
     <div class="d-flex" *ngIf="showWorkingVolumes(extendedSettings.widgetSettings)">
       <ats-working-volumes-panel
@@ -15,5 +19,3 @@
     </div>
   </div>
 </ng-container>
-
-

--- a/src/app/modules/scalper-order-book/components/current-position-panel/current-position-panel.component.html
+++ b/src/app/modules/scalper-order-book/components/current-position-panel/current-position-panel.component.html
@@ -1,10 +1,14 @@
 <ng-container *transloco="let t; scope: 'scalper-order-book/current-position-state'">
   <div
-    *ngrxLet="{ orderBookPosition: orderBookPosition$, lossOrProfitDisplayType: lossOrProfitDisplayType$} as vm"
+    *ngrxLet="{
+      orderBookPosition: orderBookPosition$,
+      lossOrProfitDisplayType: lossOrProfitDisplayType$,
+      settings: settings$
+    } as vm"
     class="container lh-1"
   >
     <div
-      [nz-tooltip]="t('scalperOrderBookCurrentPositionState.avgPositionPriceTooltip')"
+      [nz-tooltip]="vm.settings.widgetSettings.hideTooltips ? null : t('scalperOrderBookCurrentPositionState.avgPositionPriceTooltip')"
       [nzTooltipMouseEnterDelay]="1"
       class="p-2"
     >
@@ -15,7 +19,7 @@
         'positive': (vm.orderBookPosition?.qty ?? 0) > 0,
         'negative': (vm.orderBookPosition?.qty ?? 0) < 0
         }"
-         [nz-tooltip]="t('scalperOrderBookCurrentPositionState.lotsQtyTooltip')"
+         [nz-tooltip]="vm.settings.widgetSettings.hideTooltips ? null : t('scalperOrderBookCurrentPositionState.lotsQtyTooltip')"
          [nzTooltipMouseEnterDelay]="1"
          class="p-2"
     >
@@ -26,7 +30,7 @@
         'positive': (vm.orderBookPosition?.lossOrProfitPoints ?? 0) > 0,
         'negative': (vm.orderBookPosition?.lossOrProfitPoints ?? 0) < 0
         }"
-         [nz-tooltip]="t('scalperOrderBookCurrentPositionState.lossOrProfitTooltip')"
+         [nz-tooltip]="vm.settings.widgetSettings.hideTooltips ? null : t('scalperOrderBookCurrentPositionState.lossOrProfitTooltip')"
          [nzTooltipMouseEnterDelay]="1"
          (click)="changeLossOrProfitDisplayType()"
          class="p-2"

--- a/src/app/modules/scalper-order-book/components/current-position-panel/current-position-panel.component.html
+++ b/src/app/modules/scalper-order-book/components/current-position-panel/current-position-panel.component.html
@@ -2,13 +2,12 @@
   <div
     *ngrxLet="{
       orderBookPosition: orderBookPosition$,
-      lossOrProfitDisplayType: lossOrProfitDisplayType$,
-      settings: settings$
+      lossOrProfitDisplayType: lossOrProfitDisplayType$
     } as vm"
     class="container lh-1"
   >
     <div
-      [nz-tooltip]="vm.settings.widgetSettings.hideTooltips ? null : t('scalperOrderBookCurrentPositionState.avgPositionPriceTooltip')"
+      [nz-tooltip]="hideTooltips ? null : t('scalperOrderBookCurrentPositionState.avgPositionPriceTooltip')"
       [nzTooltipMouseEnterDelay]="1"
       class="p-2"
     >
@@ -19,7 +18,7 @@
         'positive': (vm.orderBookPosition?.qty ?? 0) > 0,
         'negative': (vm.orderBookPosition?.qty ?? 0) < 0
         }"
-         [nz-tooltip]="vm.settings.widgetSettings.hideTooltips ? null : t('scalperOrderBookCurrentPositionState.lotsQtyTooltip')"
+         [nz-tooltip]="hideTooltips ? null : t('scalperOrderBookCurrentPositionState.lotsQtyTooltip')"
          [nzTooltipMouseEnterDelay]="1"
          class="p-2"
     >
@@ -30,7 +29,7 @@
         'positive': (vm.orderBookPosition?.lossOrProfitPoints ?? 0) > 0,
         'negative': (vm.orderBookPosition?.lossOrProfitPoints ?? 0) < 0
         }"
-         [nz-tooltip]="vm.settings.widgetSettings.hideTooltips ? null : t('scalperOrderBookCurrentPositionState.lossOrProfitTooltip')"
+         [nz-tooltip]="hideTooltips ? null : t('scalperOrderBookCurrentPositionState.lossOrProfitTooltip')"
          [nzTooltipMouseEnterDelay]="1"
          (click)="changeLossOrProfitDisplayType()"
          class="p-2"

--- a/src/app/modules/scalper-order-book/components/limit-orders-volume-indicator/limit-orders-volume-indicator.component.html
+++ b/src/app/modules/scalper-order-book/components/limit-orders-volume-indicator/limit-orders-volume-indicator.component.html
@@ -3,7 +3,7 @@
     <span
       *ngIf="ordersVolume > 0"
       [nzTooltipMouseEnterDelay]="1"
-      [nzTooltipTitle]="t('scalperOrderBookLimitOrdersVolumeIndicator.tooltip', {side})"
+      [nzTooltipTitle]="(dataContext.extendedSettings$ | async)?.widgetSettings?.hideTooltips ? null : t('scalperOrderBookLimitOrdersVolumeIndicator.tooltip', {side})"
       class="d-inline-block lh-1 fw-bold text-center px-3 user-select-none volume-item"
       nz-tooltip
     >

--- a/src/app/modules/scalper-order-book/components/limit-orders-volume-indicator/limit-orders-volume-indicator.component.html
+++ b/src/app/modules/scalper-order-book/components/limit-orders-volume-indicator/limit-orders-volume-indicator.component.html
@@ -3,7 +3,7 @@
     <span
       *ngIf="ordersVolume > 0"
       [nzTooltipMouseEnterDelay]="1"
-      [nzTooltipTitle]="(dataContext.extendedSettings$ | async)?.widgetSettings?.hideTooltips ? null : t('scalperOrderBookLimitOrdersVolumeIndicator.tooltip', {side})"
+      [nzTooltipTitle]="hideTooltips ? null : t('scalperOrderBookLimitOrdersVolumeIndicator.tooltip', {side})"
       class="d-inline-block lh-1 fw-bold text-center px-3 user-select-none volume-item"
       nz-tooltip
     >

--- a/src/app/modules/scalper-order-book/components/limit-orders-volume-indicator/limit-orders-volume-indicator.component.ts
+++ b/src/app/modules/scalper-order-book/components/limit-orders-volume-indicator/limit-orders-volume-indicator.component.ts
@@ -20,6 +20,8 @@ export class LimitOrdersVolumeIndicatorComponent implements OnInit {
   side!: Side;
   @Input({ required: true })
   dataContext!: ScalperOrderBookDataContext;
+  @Input()
+  hideTooltips = false;
 
   ordersVolume$!: Observable<number>;
 

--- a/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.html
+++ b/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.html
@@ -3,7 +3,9 @@
     *ngIf="visible"
     [nzType]="direction === 'up' ? 'up-square' : 'down-square'"
     nz-icon nzTheme="outline"
-    [nz-tooltip]="direction === 'up' ? t('scalperOrderBookOrdersIndicator.upTooltip') : t('scalperOrderBookOrdersIndicator.downTooltip')"
+    [nz-tooltip]="hideTooltip
+      ? null
+      : direction === 'up' ? t('scalperOrderBookOrdersIndicator.upTooltip') : t('scalperOrderBookOrdersIndicator.downTooltip')"
   >
   </span>
 </ng-container>

--- a/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.html
+++ b/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.html
@@ -3,7 +3,7 @@
     *ngIf="visible"
     [nzType]="direction === 'up' ? 'up-square' : 'down-square'"
     nz-icon nzTheme="outline"
-    [nz-tooltip]="hideTooltip
+    [nz-tooltip]="hideTooltips
       ? null
       : direction === 'up' ? t('scalperOrderBookOrdersIndicator.upTooltip') : t('scalperOrderBookOrdersIndicator.downTooltip')"
   >

--- a/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.ts
+++ b/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.ts
@@ -17,5 +17,5 @@ export class OrdersIndicatorComponent {
   visible = false;
 
   @Input()
-  hideTooltip = false;
+  hideTooltips = false;
 }

--- a/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.ts
+++ b/src/app/modules/scalper-order-book/components/orders-indicator/orders-indicator.component.ts
@@ -15,4 +15,7 @@ export class OrdersIndicatorComponent {
 
   @Input({required: true})
   visible = false;
+
+  @Input()
+  hideTooltip = false;
 }

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-body/scalper-order-book-body.component.html
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-body/scalper-order-book-body.component.html
@@ -85,12 +85,18 @@
           </div>
 
           <div class="position-absolute top-0 end-0">
-            <ats-orders-indicator [visible]="(hiddenOrdersIndicators$ | async)?.up ?? false"
-                                  direction="up"></ats-orders-indicator>
+            <ats-orders-indicator
+              [visible]="(hiddenOrdersIndicators$ | async)?.up ?? false"
+              [hideTooltip]="settings.widgetSettings.hideTooltips ?? false"
+              direction="up"
+            ></ats-orders-indicator>
           </div>
           <div class="position-absolute bottom-0 end-0">
-            <ats-orders-indicator [visible]="(hiddenOrdersIndicators$ | async)?.down ?? false"
-                                  direction="down"></ats-orders-indicator>
+            <ats-orders-indicator
+              [visible]="(hiddenOrdersIndicators$ | async)?.down ?? false"
+              [hideTooltip]="settings.widgetSettings.hideTooltips ?? false"
+              direction="down"
+            ></ats-orders-indicator>
           </div>
 
           <div

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-body/scalper-order-book-body.component.html
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-body/scalper-order-book-body.component.html
@@ -62,11 +62,13 @@
                     [minWidthPx]="75"
                     [defaultWidthPercent]="50"
                   >
-                    <ats-scalper-order-book-table [dataContext]="dataContext"
-                                                  [isActive]="isActive"
-                                                  [rowHeight]="shared.rowHeight"
-                                                  (mouseenter)="isTableHovered$.next(true)"
-                                                  (mouseleave)="isTableHovered$.next(false)"
+                    <ats-scalper-order-book-table
+                      [dataContext]="dataContext"
+                      [isActive]="isActive"
+                      [rowHeight]="shared.rowHeight"
+                      [hideTooltips]="vm.extendedSettings.widgetSettings.hideTooltips ?? false"
+                      (mouseenter)="isTableHovered$.next(true)"
+                      (mouseleave)="isTableHovered$.next(false)"
                     >
                     </ats-scalper-order-book-table>
                   </ats-panel>
@@ -78,23 +80,31 @@
 
         <ng-container *ngrxLet="dataContext.extendedSettings$ as settings">
           <div class="position-absolute top-0 start-50 translate-middle-x lh-1" *ngIf="settings.widgetSettings.showLimitOrdersVolumeIndicators">
-            <ats-limit-orders-volume-indicator [dataContext]="dataContext" [side]="sides.Sell"></ats-limit-orders-volume-indicator>
+            <ats-limit-orders-volume-indicator
+              [dataContext]="dataContext"
+              [side]="sides.Sell"
+              [hideTooltips]="settings.widgetSettings.hideTooltips ?? false"
+            ></ats-limit-orders-volume-indicator>
           </div>
           <div class="position-absolute bottom-0 start-50 translate-middle-x lh-1" *ngIf="settings.widgetSettings.showLimitOrdersVolumeIndicators">
-            <ats-limit-orders-volume-indicator [dataContext]="dataContext" [side]="sides.Buy"></ats-limit-orders-volume-indicator>
+            <ats-limit-orders-volume-indicator
+              [dataContext]="dataContext"
+              [side]="sides.Buy"
+              [hideTooltips]="settings.widgetSettings.hideTooltips ?? false"
+            ></ats-limit-orders-volume-indicator>
           </div>
 
           <div class="position-absolute top-0 end-0">
             <ats-orders-indicator
               [visible]="(hiddenOrdersIndicators$ | async)?.up ?? false"
-              [hideTooltip]="settings.widgetSettings.hideTooltips ?? false"
+              [hideTooltips]="settings.widgetSettings.hideTooltips ?? false"
               direction="up"
             ></ats-orders-indicator>
           </div>
           <div class="position-absolute bottom-0 end-0">
             <ats-orders-indicator
               [visible]="(hiddenOrdersIndicators$ | async)?.down ?? false"
-              [hideTooltip]="settings.widgetSettings.hideTooltips ?? false"
+              [hideTooltips]="settings.widgetSettings.hideTooltips ?? false"
               direction="down"
             ></ats-orders-indicator>
           </div>
@@ -107,7 +117,10 @@
             (cdkDragEnded)="saveFloatingPanelPosition($event, topFloatingPanelPositionStateKey)"
             #topFloatingPanelContainer
           >
-            <ats-top-floating-panel [guid]="guid"></ats-top-floating-panel>
+            <ats-top-floating-panel
+              [guid]="guid"
+              [hideTooltips]="settings.widgetSettings.hideTooltips ?? false"
+            ></ats-top-floating-panel>
           </div>
 
           <div

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-settings/scalper-order-book-settings.component.html
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-settings/scalper-order-book-settings.component.html
@@ -144,6 +144,12 @@
                 <nz-switch formControlName='showPriceWithZeroPadding'></nz-switch>
               </nz-form-control>
             </nz-form-item>
+            <nz-form-item class="one-row">
+              <nz-form-label nzFor="hideTooltips">{{t('scalperOrderBookSettings.hideTooltipsLabel')}}</nz-form-label>
+              <nz-form-control>
+                <nz-switch formControlName="hideTooltips"></nz-switch>
+              </nz-form-control>
+            </nz-form-item>
           </nz-collapse-panel>
 
           <nz-collapse-panel [nzHeader]="t('scalperOrderBookSettings.gridSettingsLabel')">

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-settings/scalper-order-book-settings.component.ts
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-settings/scalper-order-book-settings.component.ts
@@ -163,6 +163,7 @@ export class ScalperOrderBookSettingsComponent extends WidgetSettingsBaseCompone
       ]
     ),
     showPriceWithZeroPadding: this.formBuilder.nonNullable.control(false),
+    hideTooltips: this.formBuilder.nonNullable.control(false),
     fontSize: this.formBuilder.nonNullable.control(
       12,
       [
@@ -475,6 +476,7 @@ export class ScalperOrderBookSettingsComponent extends WidgetSettingsBaseCompone
     this.form.controls.shortLongIndicatorsPanelSlot.setValue(settings.shortLongIndicatorsPanelSlot ?? PanelSlots.BottomFloatingPanel);
     this.form.controls.shortLongIndicatorsUpdateIntervalSec.setValue(settings.shortLongIndicatorsUpdateIntervalSec ?? 60);
     this.form.controls.showLimitOrdersVolumeIndicators.setValue(settings.showLimitOrdersVolumeIndicators ?? false);
+    this.form.controls.hideTooltips.setValue(settings.hideTooltips ?? false);
 
     this.form.controls.volumeDisplayFormat.setValue(settings.volumeDisplayFormat ?? NumberDisplayFormat.Default);
 

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-table/scalper-order-book-table.component.html
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-table/scalper-order-book-table.component.html
@@ -113,6 +113,7 @@
            [atsHoverItemData]="{price: row.price}"
       >
         <div
+          *ngrxLet="dataContext.extendedSettings$ | async as es"
           [ngClass]="getOrdersCellClasses(row)"
           class="table-cell"
           cdkDropList
@@ -159,7 +160,7 @@
                     'ask': isAllOrdersHaveSide(orders.orders, ordersSides.Sell),
                     'multiple': orders.orders.length > 1
                     }"
-                    [nz-tooltip]="t('scalperOrderBookScalperOrderBookTable.limitOrderTooltip')"
+                    [nz-tooltip]="es?.widgetSettings?.hideTooltips ? null : t('scalperOrderBookScalperOrderBookTable.limitOrderTooltip')"
                     [nzTooltipMouseEnterDelay]="1"
                     [nzTooltipPlacement]="['right', 'left']"
                     cdkDrag
@@ -179,7 +180,7 @@
                     'ask': isAllOrdersHaveSide(orders.orders, ordersSides.Sell),
                     'multiple': orders.orders.length > 1
                     }"
-                    [nz-tooltip]="t('scalperOrderBookScalperOrderBookTable.' + tooltipKey)"
+                    [nz-tooltip]="es?.widgetSettings?.hideTooltips ? null : t('scalperOrderBookScalperOrderBookTable.' + tooltipKey)"
                     [nzTooltipMouseEnterDelay]="1"
                     [nzTooltipPlacement]="['right', 'left']"
                     cdkDrag

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-table/scalper-order-book-table.component.html
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-table/scalper-order-book-table.component.html
@@ -113,7 +113,6 @@
            [atsHoverItemData]="{price: row.price}"
       >
         <div
-          *ngrxLet="dataContext.extendedSettings$ | async as es"
           [ngClass]="getOrdersCellClasses(row)"
           class="table-cell"
           cdkDropList
@@ -160,7 +159,7 @@
                     'ask': isAllOrdersHaveSide(orders.orders, ordersSides.Sell),
                     'multiple': orders.orders.length > 1
                     }"
-                    [nz-tooltip]="es?.widgetSettings?.hideTooltips ? null : t('scalperOrderBookScalperOrderBookTable.limitOrderTooltip')"
+                    [nz-tooltip]="hideTooltips ? null : t('scalperOrderBookScalperOrderBookTable.limitOrderTooltip')"
                     [nzTooltipMouseEnterDelay]="1"
                     [nzTooltipPlacement]="['right', 'left']"
                     cdkDrag
@@ -180,7 +179,7 @@
                     'ask': isAllOrdersHaveSide(orders.orders, ordersSides.Sell),
                     'multiple': orders.orders.length > 1
                     }"
-                    [nz-tooltip]="es?.widgetSettings?.hideTooltips ? null : t('scalperOrderBookScalperOrderBookTable.' + tooltipKey)"
+                    [nz-tooltip]="hideTooltips ? null : t('scalperOrderBookScalperOrderBookTable.' + tooltipKey)"
                     [nzTooltipMouseEnterDelay]="1"
                     [nzTooltipPlacement]="['right', 'left']"
                     cdkDrag

--- a/src/app/modules/scalper-order-book/components/scalper-order-book-table/scalper-order-book-table.component.ts
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book-table/scalper-order-book-table.component.ts
@@ -68,6 +68,9 @@ export class ScalperOrderBookTableComponent implements OnInit {
   dataContext!: ScalperOrderBookDataContext;
 
   @Input()
+  hideTooltips = false;
+
+  @Input()
   isActive = false;
 
   readonly hoveredRow$ = new Subject<{ price: number } | null>();

--- a/src/app/modules/scalper-order-book/components/scalper-order-book/scalper-order-book.component.html
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book/scalper-order-book.component.html
@@ -7,7 +7,7 @@
       <ats-scalper-order-book-body [guid]="guid" [isActive]="isActive"></ats-scalper-order-book-body>
     </div>
     <div>
-      <ats-current-position-panel [guid]="guid"></ats-current-position-panel>
+      <ats-current-position-panel [guid]="guid" [hideTooltips]="(hideTooltips$ | async) ?? false"></ats-current-position-panel>
     </div>
   </div>
 </ng-container>

--- a/src/app/modules/scalper-order-book/components/scalper-order-book/scalper-order-book.component.ts
+++ b/src/app/modules/scalper-order-book/components/scalper-order-book/scalper-order-book.component.ts
@@ -14,6 +14,7 @@ import {
 import { WidgetSettingsService } from '../../../../shared/services/widget-settings.service';
 import { ScalperSettingsHelper } from "../../utils/scalper-settings.helper";
 import { map } from "rxjs/operators";
+import { ScalperOrderBookWidgetSettings } from "../../models/scalper-order-book-settings.model";
 
 export interface ScalperOrderBookSharedContext {
   readonly workingVolume$: Observable<number | null>;
@@ -50,6 +51,8 @@ export class ScalperOrderBookComponent implements ScalperOrderBookSharedContext,
 
   gridSettings$!: Observable<{ rowHeight: number, fontSize: number }>;
 
+  hideTooltips$!: Observable<boolean>;
+
   constructor(private readonly widgetSettingsService: WidgetSettingsService) {
   }
 
@@ -67,6 +70,11 @@ export class ScalperOrderBookComponent implements ScalperOrderBookSharedContext,
       distinctUntilChanged((prev, curr) => prev.fontSize === curr.fontSize && prev.rowHeight === curr.rowHeight),
       shareReplay({ bufferSize: 1, refCount: true })
     );
+
+    this.hideTooltips$ = this.widgetSettingsService.getSettings<ScalperOrderBookWidgetSettings>(this.guid)
+      .pipe(
+        map(s => s.hideTooltips ?? false)
+      );
   }
 
   setWorkingVolume(value: number): void {

--- a/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.html
+++ b/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.html
@@ -1,18 +1,18 @@
 <ng-container *transloco="let t; scope: 'scalper-order-book/short-long-indicator'">
-  <div *ngrxLet="{ shortLongValues: shortLongValues$ | async, widgetSettings: widgetSettings$ | async } as vm"
+  <div *ngrxLet="{ shortLongValues: shortLongValues$ | async } as vm"
        [class]="orientation"
        class="d-flex fw-bold lh-1 container user-select-none"
   >
     <div
       [nzTooltipMouseEnterDelay]="1"
-      [nzTooltipTitle]="vm.widgetSettings?.hideTooltips ? null : t('scalperOrderBookShortLongIndicator.longTooltip', { count: vm.shortLongValues?.long ?? '...'})"
+      [nzTooltipTitle]="hideTooltips ? null : t('scalperOrderBookShortLongIndicator.longTooltip', { count: vm.shortLongValues?.long ?? '...'})"
       nz-tooltip
     >
       <span class="text-nowrap">L {{ vm.shortLongValues?.long ?? '...' }}</span>
     </div>
     <div
       [nzTooltipMouseEnterDelay]="1"
-      [nzTooltipTitle]="vm.widgetSettings?.hideTooltips ? null : t('scalperOrderBookShortLongIndicator.shortTooltip', { count: vm.shortLongValues?.short ?? '...'})"
+      [nzTooltipTitle]="hideTooltips ? null : t('scalperOrderBookShortLongIndicator.shortTooltip', { count: vm.shortLongValues?.short ?? '...'})"
       nz-tooltip
     >
       <span class="text-nowrap">S {{ vm.shortLongValues?.short ?? '...' }}</span>

--- a/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.html
+++ b/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.html
@@ -1,21 +1,21 @@
 <ng-container *transloco="let t; scope: 'scalper-order-book/short-long-indicator'">
-  <div *ngrxLet="shortLongValues$ as shortLongValues"
+  <div *ngrxLet="{ shortLongValues: shortLongValues$ | async, widgetSettings: widgetSettings$ | async } as vm"
        [class]="orientation"
        class="d-flex fw-bold lh-1 container user-select-none"
   >
     <div
       [nzTooltipMouseEnterDelay]="1"
-      [nzTooltipTitle]="t('scalperOrderBookShortLongIndicator.longTooltip', { count: shortLongValues?.long ?? '...'})"
+      [nzTooltipTitle]="vm.widgetSettings?.hideTooltips ? null : t('scalperOrderBookShortLongIndicator.longTooltip', { count: vm.shortLongValues?.long ?? '...'})"
       nz-tooltip
     >
-      <span class="text-nowrap">L {{ shortLongValues?.long ?? '...' }}</span>
+      <span class="text-nowrap">L {{ vm.shortLongValues?.long ?? '...' }}</span>
     </div>
     <div
       [nzTooltipMouseEnterDelay]="1"
-      [nzTooltipTitle]="t('scalperOrderBookShortLongIndicator.shortTooltip', { count: shortLongValues?.short ?? '...'})"
+      [nzTooltipTitle]="vm.widgetSettings?.hideTooltips ? null : t('scalperOrderBookShortLongIndicator.shortTooltip', { count: vm.shortLongValues?.short ?? '...'})"
       nz-tooltip
     >
-      <span class="text-nowrap">S {{ shortLongValues?.short ?? '...' }}</span>
+      <span class="text-nowrap">S {{ vm.shortLongValues?.short ?? '...' }}</span>
     </div>
   </div>
 </ng-container>

--- a/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.ts
+++ b/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.ts
@@ -31,6 +31,7 @@ import { Evaluation } from "../../../../shared/models/evaluation.model";
 import { isInstrumentEqual } from "../../../../shared/utils/settings-helper";
 import { toInstrumentKey } from "../../../../shared/utils/instruments";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { ScalperOrderBookWidgetSettings } from "../../models/scalper-order-book-settings.model";
 
 @Component({
   selector: 'ats-short-long-indicator',
@@ -46,6 +47,8 @@ export class ShortLongIndicatorComponent implements OnInit, OnDestroy {
 
   shortLongValues$ = new BehaviorSubject<{ short: number, long: number } | null>(null);
 
+  widgetSettings$!: Observable<ScalperOrderBookWidgetSettings>;
+
   constructor(
     private readonly evaluationService: EvaluationService,
     private readonly destroyRef: DestroyRef
@@ -57,19 +60,19 @@ export class ShortLongIndicatorComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    const widgetSettings$ = this.dataContext.extendedSettings$.pipe(
+    this.widgetSettings$ = this.dataContext.extendedSettings$.pipe(
       map(s => s.widgetSettings),
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-    const instrumentKey$ = widgetSettings$.pipe(
+    const instrumentKey$ = this.widgetSettings$.pipe(
       map(s => toInstrumentKey(s)),
       distinctUntilChanged((prev, curr) => isInstrumentEqual(prev, curr)),
       tap(() => this.shortLongValues$.next(null)),
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-    const updateInterval$ = widgetSettings$.pipe(
+    const updateInterval$ = this.widgetSettings$.pipe(
       map(s => s.shortLongIndicatorsUpdateIntervalSec ?? 60),
       distinct(),
       shareReplay({ bufferSize: 1, refCount: true })

--- a/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.ts
+++ b/src/app/modules/scalper-order-book/components/short-long-indicator/short-long-indicator.component.ts
@@ -31,7 +31,6 @@ import { Evaluation } from "../../../../shared/models/evaluation.model";
 import { isInstrumentEqual } from "../../../../shared/utils/settings-helper";
 import { toInstrumentKey } from "../../../../shared/utils/instruments";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { ScalperOrderBookWidgetSettings } from "../../models/scalper-order-book-settings.model";
 
 @Component({
   selector: 'ats-short-long-indicator',
@@ -43,11 +42,13 @@ export class ShortLongIndicatorComponent implements OnInit, OnDestroy {
   dataContext!: ScalperOrderBookDataContext;
 
   @Input()
+  hideTooltips = false;
+
+  @Input()
   orientation: 'vertical' | 'horizontal' = 'vertical';
 
   shortLongValues$ = new BehaviorSubject<{ short: number, long: number } | null>(null);
 
-  widgetSettings$!: Observable<ScalperOrderBookWidgetSettings>;
 
   constructor(
     private readonly evaluationService: EvaluationService,
@@ -60,19 +61,19 @@ export class ShortLongIndicatorComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.widgetSettings$ = this.dataContext.extendedSettings$.pipe(
+    const widgetSettings$ = this.dataContext.extendedSettings$.pipe(
       map(s => s.widgetSettings),
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-    const instrumentKey$ = this.widgetSettings$.pipe(
+    const instrumentKey$ = widgetSettings$.pipe(
       map(s => toInstrumentKey(s)),
       distinctUntilChanged((prev, curr) => isInstrumentEqual(prev, curr)),
       tap(() => this.shortLongValues$.next(null)),
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-    const updateInterval$ = this.widgetSettings$.pipe(
+    const updateInterval$ = widgetSettings$.pipe(
       map(s => s.shortLongIndicatorsUpdateIntervalSec ?? 60),
       distinct(),
       shareReplay({ bufferSize: 1, refCount: true })

--- a/src/app/modules/scalper-order-book/components/top-floating-panel/top-floating-panel.component.html
+++ b/src/app/modules/scalper-order-book/components/top-floating-panel/top-floating-panel.component.html
@@ -9,7 +9,7 @@
           }"
           class="fw-bold"
           nz-tooltip
-          [nzTooltipTitle]="vm.settings.hideTooltips ? null : t('scalperOrderBookTopFloatingPanel.priceDayChangePercentTooltip')"
+          [nzTooltipTitle]="hideTooltips ? null : t('scalperOrderBookTopFloatingPanel.priceDayChangePercentTooltip')"
           [nzTooltipMouseEnterDelay]="1"
         >
           {{ priceDayChangePercent }}%
@@ -21,7 +21,7 @@
       class="lh-1"
       *ngIf="currentScaleFactor$ | async as currentScaleFactor"
       nz-tooltip
-      [nzTooltipTitle]="vm.settings.hideTooltips ? null : t('scalperOrderBookTopFloatingPanel.scaleFactorTooltip')"
+      [nzTooltipTitle]="hideTooltips ? null : t('scalperOrderBookTopFloatingPanel.scaleFactorTooltip')"
       [nzTooltipMouseEnterDelay]="1"
     >
       <span class="fw-bold">x{{currentScaleFactor}}</span>

--- a/src/app/modules/scalper-order-book/components/top-floating-panel/top-floating-panel.component.html
+++ b/src/app/modules/scalper-order-book/components/top-floating-panel/top-floating-panel.component.html
@@ -9,7 +9,7 @@
           }"
           class="fw-bold"
           nz-tooltip
-          [nzTooltipTitle]="t('scalperOrderBookTopFloatingPanel.priceDayChangePercentTooltip')"
+          [nzTooltipTitle]="vm.settings.hideTooltips ? null : t('scalperOrderBookTopFloatingPanel.priceDayChangePercentTooltip')"
           [nzTooltipMouseEnterDelay]="1"
         >
           {{ priceDayChangePercent }}%
@@ -21,7 +21,7 @@
       class="lh-1"
       *ngIf="currentScaleFactor$ | async as currentScaleFactor"
       nz-tooltip
-      [nzTooltipTitle]="t('scalperOrderBookTopFloatingPanel.scaleFactorTooltip')"
+      [nzTooltipTitle]="vm.settings.hideTooltips ? null : t('scalperOrderBookTopFloatingPanel.scaleFactorTooltip')"
       [nzTooltipMouseEnterDelay]="1"
     >
       <span class="fw-bold">x{{currentScaleFactor}}</span>

--- a/src/app/modules/scalper-order-book/components/top-floating-panel/top-floating-panel.component.ts
+++ b/src/app/modules/scalper-order-book/components/top-floating-panel/top-floating-panel.component.ts
@@ -29,6 +29,9 @@ export class TopFloatingPanelComponent implements OnInit {
   @Input({ required: true })
   guid!: string;
 
+  @Input()
+  hideTooltips = false;
+
   settings$!: Observable<ScalperOrderBookWidgetSettings>;
   priceDayChangePercent$!: Observable<number>;
   currentScaleFactor$!: Observable<number | null>;

--- a/src/app/modules/scalper-order-book/models/scalper-order-book-settings.model.ts
+++ b/src/app/modules/scalper-order-book/models/scalper-order-book-settings.model.ts
@@ -92,6 +92,7 @@ export interface ScalperOrderBookWidgetSettings extends WidgetSettings, Instrume
   shortLongIndicatorsPanelSlot?: PanelSlots.BottomFloatingPanel | PanelSlots.TopPanel;
   shortLongIndicatorsUpdateIntervalSec?: number;
   showLimitOrdersVolumeIndicators?: boolean;
+  hideTooltips?: boolean;
   rowHeight?: number;
   fontSize?: number;
   instrumentLinkedSettings?: {

--- a/src/assets/i18n/scalper-order-book/settings/en.json
+++ b/src/assets/i18n/scalper-order-book/settings/en.json
@@ -46,6 +46,7 @@
   "rulerSettingsLabel": "Ruler settings",
   "markerDisplayFormatLabel": "Marker value",
   "showPriceWithZeroPaddingLabel": "Display prices with the same number of decimal places",
+  "hideTooltipsLabel": "Hide tooltips",
   "bracketsSettingsLabel": "Bracket settings",
   "orderPriceUnitsLabel": "Price units",
   "topOrderPriceRatioLabel": "Order to close a position at a profit",

--- a/src/assets/i18n/scalper-order-book/settings/ru.json
+++ b/src/assets/i18n/scalper-order-book/settings/ru.json
@@ -46,6 +46,7 @@
   "rulerSettingsLabel": "Настройки линейки",
   "markerDisplayFormatLabel": "Значение маркера",
   "showPriceWithZeroPaddingLabel": "Отображать цены с одинаковым количеством знаков после запятой",
+  "hideTooltipsLabel": "Отключить всплывающие подсказки",
   "bracketsSettingsLabel": "Настройки коридора",
   "orderPriceUnitsLabel": "Единицы цены",
   "topOrderPriceRatioLabel": "Условная заявка на закрытие позиции по прибыли",


### PR DESCRIPTION
Fixes #1695 

# Description

add hide-tooltip setting in scalper orderbook

# Testing

open scalper orderbook widget
open settings
in display settings turn on hide tooltips switch

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
