### PR TITLE
#1833 Fix scalper orderbook trades aggregation

### DIFF
--- a/src/app/modules/scalper-order-book/utils/aggregated-trades-iterator.spec.ts
+++ b/src/app/modules/scalper-order-book/utils/aggregated-trades-iterator.spec.ts
@@ -1,6 +1,7 @@
 ﻿import { Side } from "src/app/shared/models/enums/side.model";
 import { AllTradesItem } from "../../../shared/models/all-trades.model";
 import { AggregatedTradesIterator } from "./aggregated-trades-iterator";
+import { CustomIteratorWrapper } from "../../../shared/utils/array-iterators";
 
 describe('AggregatedTradesIterator', () => {
   const createTrade = (price: number, side: Side, qty: number, timestamp: number): AllTradesItem => {
@@ -251,5 +252,68 @@ describe('AggregatedTradesIterator', () => {
           .toEqual(testCase.done);
       }
     });
+  });
+
+  it('should correctly apply aggregation when some deals are ahead of another', () => {
+    const timeframe = 52;
+    const tradesData = [
+      {
+        "id": 1892949987524967700,
+        "orderno": 0,
+        "symbol": "SI-12.24",
+        "board": "RFUD",
+        "qty": 1,
+        "price": 94971,
+        "time": "2024-10-18T11:24:57.6674490Z",
+        "timestamp": 1729250697667,
+        "oi": 5366242,
+        "existing": false,
+        "side": "sell"
+      },
+      {
+        "id": 1892949987524967700,
+        "orderno": 0,
+        "symbol": "SI-12.24",
+        "board": "RFUD",
+        "qty": 1,
+        "price": 94968,
+        "time": "2024-10-18T11:24:57.6684880Z",
+        "timestamp": 1729250697668,
+        "oi": 5366240,
+        "existing": false,
+        "side": "sell"
+      },
+      {
+        "id": 1892949987524967700,
+        "orderno": 0,
+        "symbol": "SI-12.24",
+        "board": "RFUD",
+        "qty": 2,
+        "price": 94971,
+        "time": "2024-10-18T11:24:57.6666920Z",
+        "timestamp": 1729250697666,
+        "oi": 5366242,
+        "existing": false,
+        "side": "sell"
+      }
+    ];
+
+    const trades: AllTradesItem[] = tradesData.map(x =>
+      createTrade(
+        x['price'],
+        x['side'] == 'buy' ? Side.Buy : Side.Sell,
+        x['qty'],
+        x['timestamp']
+      )
+    );
+
+    for (const trade of new CustomIteratorWrapper(() => new AggregatedTradesIterator(trades, timeframe))) {
+      expect(trade)
+        .not.toBeNull();
+
+      if (trade == null) {
+        break;
+      }
+    }
   });
 });

--- a/src/app/modules/scalper-order-book/utils/aggregated-trades-iterator.ts
+++ b/src/app/modules/scalper-order-book/utils/aggregated-trades-iterator.ts
@@ -86,6 +86,11 @@ export class AggregatedTradesIterator implements Iterator<AggregatedTrade | null
       const tradeSide = currentTrade.side as Side;
       lastSide = lastSide ?? tradeSide;
 
+      if (currentTrade.timestamp > bounds.end) {
+        this.currentIndex--;
+        continue;
+      }
+
       if (currentTrade.timestamp >= bounds.start && currentTrade.timestamp <= bounds.end) {
         if (tradeSide === lastSide) {
           aggregatedTrades.push(currentTrade);


### PR DESCRIPTION
Fixes #1833

# Description

Ignore trades which timestamp is higher than upper bound of currrent aggregation range.

# Testing

Add test with corresponding trades data

# Risk

No major changes

# Do you agree with those?
- [] I agree to follow the [Contributing guidelines](https://github.com/alor-broker/Astras-Trading-UI/blob/master/CONTRIBUTING.md)
- [] I agree to follow the terms of the [Code of Conduct](https://github.com/alor-broker/.github/blob/master/CODE_OF_CONDUCT.md)
