### PR TITLE
Enforce non-zero notification price and disable chart fullscreen on mobile

### DIFF
--- a/src/app/modules/push-notifications/components/setup-instrument-notifications/setup-instrument-notifications.component.spec.ts
+++ b/src/app/modules/push-notifications/components/setup-instrument-notifications/setup-instrument-notifications.component.spec.ts
@@ -16,6 +16,7 @@ import {NzDividerComponent} from "ng-zorro-antd/divider";
 import {InputNumberComponent} from "../../../../shared/components/input-number/input-number.component";
 import {NzTypographyComponent} from "ng-zorro-antd/typography";
 import {FormsTesting} from "../../../../shared/utils/testing/forms-testing";
+import {LessMore} from "../../../../shared/models/enums/less-more.model";
 
 describe('SetupInstrumentNotificationsComponent', () => {
   let component: SetupInstrumentNotificationsComponent;
@@ -80,5 +81,19 @@ describe('SetupInstrumentNotificationsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should invalidate form when price is 0', () => {
+    component.newPriceChangeSubscriptionForm.controls.price.setValue(0);
+    component.newPriceChangeSubscriptionForm.controls.priceCondition.setValue(LessMore.More);
+
+    expect(component.newPriceChangeSubscriptionForm.valid).toBeFalse();
+  });
+
+  it('should validate form when price is greater than 0', () => {
+    component.newPriceChangeSubscriptionForm.controls.price.setValue(0.01);
+    component.newPriceChangeSubscriptionForm.controls.priceCondition.setValue(LessMore.More);
+
+    expect(component.newPriceChangeSubscriptionForm.valid).toBeTrue();
   });
 });

--- a/src/app/modules/push-notifications/components/setup-instrument-notifications/setup-instrument-notifications.component.ts
+++ b/src/app/modules/push-notifications/components/setup-instrument-notifications/setup-instrument-notifications.component.ts
@@ -62,6 +62,8 @@ import {AsyncPipe} from '@angular/common';
   ]
 })
 export class SetupInstrumentNotificationsComponent implements OnInit, OnDestroy {
+  private static readonly minNotificationPrice = Number.EPSILON;
+
   private readonly pushNotificationsService = inject(PushNotificationsService);
   private readonly commonParametersService = inject(CommonParametersService);
   private readonly quoteService = inject(QuotesService);
@@ -77,7 +79,7 @@ export class SetupInstrumentNotificationsComponent implements OnInit, OnDestroy 
       null,
       [
         Validators.required,
-        Validators.min(inputNumberValidation.min),
+        Validators.min(SetupInstrumentNotificationsComponent.minNotificationPrice),
         Validators.max(inputNumberValidation.max)
       ]
     ),

--- a/src/app/modules/tech-chart/components/tech-chart/tech-chart.component.ts
+++ b/src/app/modules/tech-chart/components/tech-chart/tech-chart.component.ts
@@ -299,7 +299,7 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
 
     this.localStorageService.removeItem('tradingview.current_theme.name');
 
-    const features = this.getFeatures(settings);
+    const features = this.getFeatures(settings, deviceInfo);
 
     this.techChartDatafeedService.setExchangeSettings(exchanges);
     const config: ChartingLibraryWidgetOptions = {
@@ -668,7 +668,10 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
     };
   }
 
-  private getFeatures(settings: TechChartSettings): { enabled: ChartingLibraryFeatureset[], disabled: ChartingLibraryFeatureset[] } {
+  private getFeatures(
+    settings: TechChartSettings,
+    deviceInfo: DeviceInfo
+  ): { enabled: ChartingLibraryFeatureset[], disabled: ChartingLibraryFeatureset[] } {
     const enabled = new Set<ChartingLibraryFeatureset>([
       'side_toolbar_in_fullscreen_mode',
       'chart_crosshair_menu' as ChartingLibraryFeatureset,
@@ -696,7 +699,12 @@ export class TechChartComponent implements OnInit, OnDestroy, AfterViewInit {
     this.switchChartFeature('header_screenshot', settings.panels?.headerScreenshot ?? true, enabled, disabled);
     this.switchChartFeature('header_settings', settings.panels?.headerSettings ?? true, enabled, disabled);
     this.switchChartFeature('header_undo_redo', settings.panels?.headerUndoRedo ?? true, enabled, disabled);
-    this.switchChartFeature('header_fullscreen_button', settings.panels?.headerFullscreenButton ?? true, enabled, disabled);
+    this.switchChartFeature(
+      'header_fullscreen_button',
+      !deviceInfo.isMobile && (settings.panels?.headerFullscreenButton ?? true),
+      enabled,
+      disabled
+    );
     this.switchChartFeature('left_toolbar', settings.panels?.drawingsToolbar ?? true, enabled, disabled);
     this.switchChartFeature('timeframes_toolbar', settings.panels?.timeframesBottomToolbar ?? true, enabled, disabled);
     this.switchChartFeature('custom_resolutions', settings.allowCustomTimeframes ?? false, enabled, disabled);


### PR DESCRIPTION
Fixes #2214
Fixes #2212

### Motivation

- Prevent subscriptions with a price of exactly `0` which are invalid for price-change notifications. 
- Prevent showing a fullscreen header button in the tech chart on mobile devices to avoid unsupported UI on smaller screens.

### Description

- Introduced a private static `minNotificationPrice` set to `Number.EPSILON` and replaced the previous `Validators.min` lower bound with `SetupInstrumentNotificationsComponent.minNotificationPrice` to require a strictly positive price. 
- Added two unit tests in `setup-instrument-notifications.component.spec.ts` that assert the price form is invalid when `price` is `0` and valid when `price` is `0.01`, and imported the `LessMore` enum used by the form. 
- Updated `TechChartComponent.getFeatures` to accept a `deviceInfo: DeviceInfo` parameter and changed the call site to pass `deviceInfo`, and gated the `header_fullscreen_button` feature with `!deviceInfo.isMobile && (settings.panels?.headerFullscreenButton ?? true)` so the fullscreen button is disabled on mobile.

### Testing

- Added unit tests in `src/app/modules/push-notifications/components/setup-instrument-notifications/setup-instrument-notifications.component.spec.ts` and ran the test suite; the new tests passed. 
- Ran the project's automated unit tests (`ng test`) and observed the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7cf180640832088f8f9fd166a5f4a)