### PR TITLE
Swap Bid/Ask display order in compact order form header

### DIFF
--- a/src/app/modules/order-commands/components/compact-header/compact-header.component.html
+++ b/src/app/modules/order-commands/components/compact-header/compact-header.component.html
@@ -19,12 +19,12 @@
         </div>
         @if (priceData$ | async; as priceData) {
           <div>
-            <label>Ask: </label>
-            <span (click)="priceSelected.emit(priceData.ask)" class="selectable sell">{{priceData.ask | atsPrice: getPriceDecimalSymbolsCount(instrument)}}</span>
-          </div>
-          <div>
             <label>Bid: </label>
             <span (click)="priceSelected.emit(priceData.bid)" class="selectable buy">{{priceData.bid | atsPrice:  getPriceDecimalSymbolsCount(instrument)}}</span>
+          </div>
+          <div>
+            <label>Ask: </label>
+            <span (click)="priceSelected.emit(priceData.ask)" class="selectable sell">{{priceData.ask | atsPrice: getPriceDecimalSymbolsCount(instrument)}}</span>
           </div>
         }
       </div>


### PR DESCRIPTION
Fixes #2149

### Motivation
- Align the compact order form header with the order book UI by displaying `Bid` before `Ask` for a consistent user experience.

### Description
- Reordered the `Bid`/`Ask` blocks in `src/app/modules/order-commands/components/compact-header/compact-header.component.html` so `Bid` is rendered before `Ask`, while preserving existing `(click)` handlers and `buy`/`sell` styling.

### Testing
- `pnpm lint` completed successfully; `pnpm test` failed in the pre-commit environment due to missing `ChromeHeadless` (`CHROME_BIN` not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f442f9208320a96017da16a88e00)